### PR TITLE
feat: off-route detection and handling (E7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ FIRMWARE_ELF := target/thumbv8m.main-none-eabi/release/pico2-firmware
 # Route configuration (can be overridden)
 ROUTE_NAME ?= ty225
 SCENARIO ?= normal
+SHORTCUT_FROM_STOP ?= 1
+SHORTCUT_TO_STOP ?= 5
 
 # Input files
 ROUTE_JSON := $(DATA_DIR)/$(ROUTE_NAME)_route.json
@@ -40,6 +42,7 @@ STOPS_JSON := $(DATA_DIR)/$(ROUTE_NAME)_stops.json
 # Output files (named by route and scenario)
 NMEA_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_nmea.txt
 ROUTE_DATA_BIN := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO).bin
+GROUND_TRUTH_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_gt.json
 # SIMULATOR_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_sim.json  # Deprecated
 DETECTOR_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_arrivals.json
 TRACE_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_trace.jsonl
@@ -123,8 +126,11 @@ gen_nmea:
 		--route $(ROUTE_JSON) \
 		--stops $(STOPS_JSON) \
 		--scenario $(SCENARIO) \
-		--out_nmea $(NMEA_OUT)
+		--out_nmea $(NMEA_OUT) \
+		--out_gt $(GROUND_TRUTH_OUT) \
+		$(if $(filter shortcut,$(SCENARIO)),--shortcut-from-stop $(SHORTCUT_FROM_STOP) --shortcut-to-stop $(SHORTCUT_TO_STOP))
 	@echo "Generated: $(NMEA_OUT)"
+	@echo "Generated: $(GROUND_TRUTH_OUT)"
 
 # Preprocess route and stops into binary route data
 preprocess:

--- a/tools/gen_nmea/gen_nmea.js
+++ b/tools/gen_nmea/gen_nmea.js
@@ -40,8 +40,18 @@ const GENERATE_SCHEMA = {
     "scenario": {
       "type": "string",
       "description": "Simulation scenario preset",
-      "enum": ["normal", "drift", "jump", "outage"],
+      "enum": ["normal", "drift", "jump", "outage", "shortcut"],
       "default": "normal"
+    },
+    "shortcut_from_stop": {
+      "type": "number",
+      "description": "Starting stop index for shortcut (0-based, only used when scenario=shortcut)",
+      "default": 1
+    },
+    "shortcut_to_stop": {
+      "type": "number",
+      "description": "Ending stop index for shortcut (0-based, only used when scenario=shortcut)",
+      "default": 5
     },
     "outage_start_seg": {
       "type": "number",
@@ -125,6 +135,8 @@ function parseArgs(argv) {
     scenario: 'normal',
     outage_start_seg: 15,
     outage_end_seg: 17,
+    shortcut_from_stop: 1,
+    shortcut_to_stop: 5,
     out_nmea: 'test.nmea',
     out_gt: 'ground_truth.json',
   };
@@ -172,6 +184,16 @@ function parseArgs(argv) {
 
     if (arg === '--scenario') {
       args.scenario = argv[++i];
+      continue;
+    }
+
+    if (arg === '--shortcut-from-stop') {
+      args.shortcut_from_stop = parseInt(argv[++i]);
+      continue;
+    }
+
+    if (arg === '--shortcut-to-stop') {
+      args.shortcut_to_stop = parseInt(argv[++i]);
       continue;
     }
 
@@ -243,10 +265,11 @@ function parseArgs(argv) {
 // ─── 常數 / 場景設定 ─────────────────────────────────────────────────────────
 
 const SCENARIOS = {
-  normal: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false },
-  drift: { hdop: 7.0, sigmaM: 35, sigmaHeading: 15.0, sats: 5, jump: false, outage: false, canyon: true },
-  jump: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: true, outage: false, canyon: false },
-  outage: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: false, outage: true, canyon: false },
+  normal: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: false },
+  drift: { hdop: 7.0, sigmaM: 35, sigmaHeading: 15.0, sats: 5, jump: false, outage: false, canyon: true, shortcut: false },
+  jump: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: true, outage: false, canyon: false, shortcut: false },
+  outage: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: false, outage: true, canyon: false, shortcut: false },
+  shortcut: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: true },
 };
 
 const CRUISE_KMH = 28;
@@ -457,7 +480,7 @@ function simulate(route, cfg) {
   const segs = buildSegments(route_points, stops, traffic_lights || []);
   const totalDist = segs.reduce((s, g) => s + g.dist, 0);
 
-  const { hdop, sigmaM, sigmaHeading, sats, outageStartSeg, outageEndSeg } = cfg;
+  const { hdop, sigmaM, sigmaHeading, sats, outageStartSeg, outageEndSeg, shortcut, shortcutFromStop, shortcutToStop } = cfg;
   const noiseN = new AR1Noise(sigmaM);
   const noiseE = new AR1Noise(sigmaM);
   const noiseHeading = new AR1Noise(sigmaHeading);
@@ -471,6 +494,26 @@ function simulate(route, cfg) {
   let ts = BASE_TS;
   let travelledDist = 0;
   let stopSeqIdx = 0;
+
+  // Build stop index mapping for shortcut scenario
+  const stopIndexMap = [];
+  let stopCount = 0;
+  for (let i = 0; i < segs.length; i++) {
+    if (segs[i].stopBefore) {
+      stopIndexMap[i] = stopCount++;
+    }
+  }
+
+  // Helper to emit GPS at a position
+  const emitGPS = (lat, lon, speedMs, brng, outage = false) => {
+    if (!outage) {
+      const [nl, no] = addNoiseMeters([lat, lon], noiseN.next(), noiseE.next());
+      const noisyBearing = (brng + noiseHeading.next() + 360) % 360;
+      nmeaLines.push(makeGPRMC(ts, nl, no, speedMs * 1.94384, noisyBearing));
+      nmeaLines.push(makeGPGGA(ts, nl, no, hdop, sats));
+    }
+    ts++;
+  };
 
   // 輸出一秒靜止訊號的輔助函式
   const emitStatic = (pos, brng, outage) => {
@@ -495,10 +538,81 @@ function simulate(route, cfg) {
     for (let t = 0; t < dwell; t++) emitStatic(firstSeg.from, firstSeg.bearing, isOutage);
   }
 
+  // Shortcut state
+  let shortcutActive = false;
+  let shortcutCompleted = false;
+
   for (let si = 0; si < segs.length; si++) {
     const seg = segs[si];
     const isOutage = cfg.outage && si >= outageStartSeg && si <= outageEndSeg;
     const prevSeg = si > 0 ? segs[si - 1] : null;
+
+    // Check for shortcut trigger
+    if (shortcut && !shortcutActive && !shortcutCompleted && seg.stopBefore && stopIndexMap[si] === shortcutFromStop) {
+      shortcutActive = true;
+      console.log(`Shortcut triggered at stop ${shortcutFromStop}, going to stop ${shortcutToStop}`);
+
+      // Find the coordinates of from_stop and to_stop
+      const fromStopIdx = stops.indexOf(stops.find((s, i) => stopIndexMap[segs.findIndex(seg => seg.stopBefore && stopIndexMap[segs.indexOf(seg)] === shortcutFromStop)] === shortcutFromStop) || stops[shortcutFromStop]);
+      const toStopIdx = stops.indexOf(stops.find((s, i) => stopIndexMap[segs.findIndex(seg => seg.stopBefore && stopIndexMap[segs.indexOf(seg)] === shortcutToStop)] === shortcutToStop) || stops[shortcutToStop]);
+
+      // Get coordinates from route points
+      const fromLat = seg.from[0];
+      const fromLon = seg.from[1];
+
+      // Find the segment containing the to_stop
+      const toSegIdx = segs.findIndex(s => s.stopBefore && stopIndexMap[segs.indexOf(s)] === shortcutToStop);
+      if (toSegIdx >= 0) {
+        const toLat = segs[toSegIdx].from[0];
+        const toLon = segs[toSegIdx].from[1];
+
+        // Calculate shortcut distance and bearing
+        const shortcutDist = haversine([fromLat, fromLon], [toLat, toLon]);
+        const shortcutBearing = bearing([fromLat, fromLon], [toLat, toLon]);
+
+        console.log(`Shortcut: ${shortcutDist.toFixed(0)}m, bearing ${shortcutBearing.toFixed(1)}°`);
+
+        // Dwell at from_stop before shortcut
+        emitStatic([fromLat, fromLon], shortcutBearing, false);
+        groundTruth.push({ stop_idx: stopSeqIdx, lat: fromLat, lon: fromLon, timestamp: ts - STOP_DWELL_S, phase: 'shortcut_start', event: 'departure_shortcut' });
+
+        // Generate GPS points along shortcut
+        const shortcutStartTS = ts;
+        let traveled = 0;
+        let speedMs = CRUISE_MS * 0.4;
+
+        while (traveled < shortcutDist) {
+          const targetMs = CRUISE_MS;
+          if (speedMs < targetMs) speedMs = Math.min(speedMs + ACCEL_MS2, targetMs);
+          else speedMs = Math.max(speedMs - DECEL_MS2, targetMs);
+
+          const step = Math.min(speedMs, shortcutDist - traveled);
+          traveled += step;
+
+          const frac = traveled / shortcutDist;
+          const lat = fromLat + (toLat - fromLat) * frac;
+          const lon = fromLon + (toLon - fromLon) * frac;
+          emitGPS(lat, lon, speedMs, shortcutBearing, false);
+        }
+
+        const offRouteDuration = ts - shortcutStartTS;
+        console.log(`Shortcut duration: ${offRouteDuration}s`);
+        groundTruth.push({ stop_idx: stopSeqIdx, lat: toLat, lon: toLon, timestamp: ts, phase: 'shortcut_end', event: 're_acquisition', off_route_duration_s: offRouteDuration });
+      }
+    }
+
+    // Skip segments during shortcut (we've already injected GPS)
+    if (shortcutActive) {
+      if (seg.stopBefore && stopIndexMap[si] === shortcutToStop) {
+        shortcutActive = false;
+        shortcutCompleted = true;
+        console.log(`Shortcut completed at stop ${shortcutToStop}, resuming normal route`);
+        // Continue processing this segment normally
+      } else {
+        // Skip this segment during shortcut
+        continue;
+      }
+    }
 
     // DEBUG: Log every 20th segment
     if (si % 20 === 0) {
@@ -612,9 +726,11 @@ GENERATE OPTIONS:
   --json-payload '{"route":"path","scenario":"normal"}'    Structured JSON input (recommended for agents)
   --route <path>                                           Route JSON file (default: route.json)
   --stops <path>                                           Stops JSON file with lat/lon (optional, uses route.stops if not provided)
-  --scenario <name>                                        Scenario: normal, drift, jump, outage (default: normal)
+  --scenario <name>                                        Scenario: normal, drift, jump, outage, shortcut (default: normal)
   --outage-start-seg <num>                                 Starting segment index for GPS outage (default: 15)
   --outage-end-seg <num>                                   Ending segment index for GPS outage (default: 17)
+  --shortcut-from-stop <num>                               Starting stop index for shortcut (default: 1)
+  --shortcut-to-stop <num>                                 Ending stop index for shortcut (default: 5)
   --out-nmea <path>                                        NMEA output file (default: test.nmea)
   --out-gt <path>                                          Ground truth output file (default: ground_truth.json)
 
@@ -630,6 +746,7 @@ SCENARIOS:
   drift     HDOP=7.0, σ(pos)=35m, σ(heading)=15°, 5 sats, urban canyon drift
   jump      Normal GPS, but with 100m+ position jump at 30% distance
   outage    GPS signal outage on segments 15-17
+  shortcut  Bus takes shortcut from --shortcut-from-stop to --shortcut-to-stop (off-route)
 
 AGENT USAGE EXAMPLES:
   # Step 1: Discover parameter shapes
@@ -688,6 +805,12 @@ function cmdGenerate(args) {
   if (args.scenario === 'outage') {
     cfg.outageStartSeg = args.outage_start_seg;
     cfg.outageEndSeg = args.outage_end_seg;
+  }
+
+  // Add custom shortcut parameters for shortcut scenario
+  if (args.scenario === 'shortcut') {
+    cfg.shortcutFromStop = args.shortcut_from_stop;
+    cfg.shortcutToStop = args.shortcut_to_stop;
   }
 
   // Load route file

--- a/tools/gen_shortcut_sim.js
+++ b/tools/gen_shortcut_sim.js
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Generate NMEA for shortcut scenario: bus goes off-route from stop 6 to stop 10
+ * This tests the off-route detection system.
+ *
+ * Route: ty225_short (stops 5-13 from ty225)
+ * Shortcut: Bus deviates from route at stop 6, goes straight to stop 10
+ * Expected behavior: Off-route detected after 5+ seconds, position frozen
+ */
+
+const fs = require('fs');
+
+// Constants from gen_nmea.js
+const EARTH_R = 6_371_000;
+const BASE_TS = 1_700_000_000;
+const CRUISE_KMH = 28;
+const CRUISE_MS = CRUISE_KMH / 3.6;
+const MAX_KMH = 50;
+const MAX_MS = MAX_KMH / 3.6;
+const ACCEL_MS2 = 1.2;
+const DECEL_MS2 = 1.8;
+const STOP_DWELL_S = 8;
+const HDOP = 3.5;
+const SATS = 8;
+
+// AR(1) noise parameters
+const AR1_ALPHA = 0.7;
+const DRIFT_DECAY = 0.98;
+
+function toRad(deg) { return deg * Math.PI / 180; }
+function toDeg(rad) { return rad * 180 / Math.PI; }
+
+function haversine(lat1, lon1, lat2, lon2) {
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_R * Math.asin(Math.sqrt(a));
+}
+
+function bearing(lat1, lon1, lat2, lon2) {
+  const dLon = toRad(lon2 - lon1);
+  const y = Math.sin(dLon) * Math.cos(toRad(lat2));
+  const x = Math.cos(toRad(lat1)) * Math.sin(toRad(lat2)) -
+    Math.sin(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.cos(dLon);
+  return (toDeg(Math.atan2(y, x)) + 360) % 360;
+}
+
+function movePoint(lat, lon, brng, dist) {
+  const d = dist / EARTH_R;
+  const b = toRad(brng);
+  const φ1 = toRad(lat), λ1 = toRad(lon);
+  const φ2 = Math.asin(Math.sin(φ1) * Math.cos(d) +
+    Math.cos(φ1) * Math.sin(d) * Math.cos(b));
+  const λ2 = λ1 + Math.atan2(
+    Math.sin(b) * Math.sin(d) * Math.cos(φ1),
+    Math.cos(d) - Math.sin(φ1) * Math.sin(φ2));
+  return [toDeg(φ2), toDeg(λ2)];
+}
+
+function randn() {
+  let u = 0, v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function addNoiseMeters(lat, lon, noiseLat, noiseLon) {
+  const [lat2, lon2] = movePoint(lat, lon, 0, noiseLat);
+  const [lat3, lon3] = movePoint(lat2, lon2, 90, noiseLon);
+  return [lat3, lon3];
+}
+
+class AR1Noise {
+  constructor(sigma) {
+    this.sigma = sigma;
+    this.prev = 0;
+    this.drift = 0;
+  }
+  next() {
+    this.prev = AR1_ALPHA * this.prev + Math.sqrt(1 - AR1_ALPHA ** 2) * randn() * this.sigma;
+    this.drift = DRIFT_DECAY * this.drift + (1 - DRIFT_DECAY) * randn() * this.sigma * 0.5;
+    return this.prev + this.drift;
+  }
+}
+
+// NMEA generation
+function nmeaChecksum(sentence) {
+  let cs = 0;
+  for (let i = 0; i < sentence.length; i++) cs ^= sentence.charCodeAt(i);
+  return cs.toString(16).toUpperCase().padStart(2, '0');
+}
+
+function formatDDMM(deg, isLat) {
+  const abs = Math.abs(deg);
+  const d = Math.floor(abs);
+  const m = (abs - d) * 60;
+  const mStr = m.toFixed(4).padStart(7, '0');
+  const dStr = isLat ? String(d).padStart(2, '0') : String(d).padStart(3, '0');
+  return `${dStr}${mStr}`;
+}
+
+function tsToNmeaTime(ts) {
+  const d = new Date(ts * 1000);
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  const ss = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${hh}${mm}${ss}`;
+}
+
+function tsToNmeaDate(ts) {
+  const d = new Date(ts * 1000);
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  const mo = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const yy = String(d.getUTCFullYear()).slice(-2);
+  return `${dd}${mo}${yy}`;
+}
+
+function makeGPRMC(ts, lat, lon, speedKnots, brng) {
+  const NS = lat >= 0 ? 'N' : 'S';
+  const EW = lon >= 0 ? 'E' : 'W';
+  const body = `GPRMC,${tsToNmeaTime(ts)},A,${formatDDMM(lat, true)},${NS},` +
+    `${formatDDMM(lon, false)},${EW},${speedKnots.toFixed(1)},` +
+    `${brng.toFixed(1)},${tsToNmeaDate(ts)},,`;
+  return `$${body}*${nmeaChecksum(body)}`;
+}
+
+function makeGPGGA(ts, lat, lon, hdop, sats) {
+  const NS = lat >= 0 ? 'N' : 'S';
+  const EW = lon >= 0 ? 'E' : 'W';
+  const body = `GPGGA,${tsToNmeaTime(ts)},${formatDDMM(lat, true)},${NS},` +
+    `${formatDDMM(lon, false)},${EW},1,${String(sats).padStart(2, '0')},` +
+    `${hdop.toFixed(1)},10.0,M,0.0,M,,`;
+  return `$${body}*${nmeaChecksum(body)}`;
+}
+
+// Load route
+const routeFile = process.argv[2] || '../test_data/ty225_short_route.json';
+const route = JSON.parse(fs.readFileSync(routeFile, 'utf8'));
+const stops = JSON.parse(fs.readFileSync('../test_data/ty225_short_stops.json', 'utf8')).stops;
+
+console.log(`Route has ${route.route_points.length} points, ${stops.length} stops`);
+
+// Generate segments from route points
+const segments = [];
+for (let i = 0; i < route.route_points.length - 1; i++) {
+  const from = route.route_points[i];
+  const to = route.route_points[i + 1];
+  segments.push({
+    from,
+    to,
+    dist: haversine(from[0], from[1], to[0], to[1]),
+    bearing: bearing(from[0], from[1], to[0], to[1]),
+  });
+}
+
+// Find which segment each stop is on
+const stopSegments = [];
+for (const stop of stops) {
+  let minDist = Infinity;
+  let minSegIdx = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const dist = haversine(stop.lat, stop.lon, segments[i].from[0], segments[i].from[1]);
+    if (dist < minDist) {
+      minDist = dist;
+      minSegIdx = i;
+    }
+  }
+  stopSegments.push(minSegIdx);
+}
+
+console.log('Stop segments:', stopSegments);
+
+// Simulation
+const nmeaLines = [];
+const groundTruth = [];
+const trace = []; // For trace.jsonl
+
+let ts = BASE_TS;
+let stopSeqIdx = 0;
+const noiseN = new AR1Noise(15);
+const noiseE = new AR1Noise(15);
+const noiseHeading = new AR1Noise(5.0);
+
+// Helper to emit GPS at a position
+function emitGPS(lat, lon, speedMs, brng) {
+  const [nl, no] = addNoiseMeters(lat, lon, noiseN.next(), noiseE.next());
+  const noisyBearing = (brng + noiseHeading.next() + 360) % 360;
+  nmeaLines.push(makeGPRMC(ts, nl, no, speedMs * 1.94384, noisyBearing));
+  nmeaLines.push(makeGPGGA(ts, nl, no, HDOP, SATS));
+  trace.push({ ts, lat: nl, lon: no, speed_cms: Math.round(speedMs * 100), heading_cdeg: Math.round(noisyBearing * 100) });
+  ts++;
+}
+
+// Helper to emit stationary GPS (at stop)
+function emitStatic(lat, lon, brng, duration) {
+  for (let t = 0; t < duration; t++) {
+    emitGPS(lat, lon, 0, brng);
+  }
+}
+
+// Phase 1: Normal from stop 5 to stop 6
+console.log('\\nPhase 1: Stop 5 to Stop 6 (normal)');
+for (let segIdx = stopSegments[0]; segIdx <= stopSegments[1]; segIdx++) {
+  const seg = segments[segIdx];
+  groundTruth.push({ stop_idx: stopSeqIdx, seg_idx: segIdx, phase: 'normal_to_stop6' });
+
+  // Dwell at stop 5
+  if (segIdx === stopSegments[0]) {
+    emitStatic(seg.from[0], seg.from[1], seg.bearing, STOP_DWELL_S);
+  }
+
+  // Travel segment
+  let traveled = 0;
+  let speedMs = CRUISE_MS * 0.4;
+  while (traveled < seg.dist) {
+    const targetMs = CRUISE_MS;
+    if (speedMs < targetMs) speedMs = Math.min(speedMs + ACCEL_MS2, targetMs);
+    else speedMs = Math.max(speedMs - DECEL_MS2, targetMs);
+
+    const step = Math.min(speedMs, seg.dist - traveled);
+    traveled += step;
+
+    const frac = traveled / seg.dist;
+    const lat = seg.from[0] + (seg.to[0] - seg.from[0]) * frac;
+    const lon = seg.from[1] + (seg.to[1] - seg.from[1]) * frac;
+    emitGPS(lat, lon, speedMs, seg.bearing);
+  }
+}
+stopSeqIdx++;
+
+// Phase 2: OFF-ROUTE - straight from stop 6 to stop 10 (shortcut)
+console.log('\\nPhase 2: OFF-ROUTE Stop 6 to Stop 10 (shortcut)');
+const stop6 = stops[1]; // Stop 6 (index 1 in our array)
+const stop10 = stops[5]; // Stop 10 (index 5 in our array)
+
+// Create shortcut path
+const shortcutDist = haversine(stop6.lat, stop6.lon, stop10.lat, stop10.lon);
+const shortcutBearing = bearing(stop6.lat, stop6.lon, stop10.lat, stop10.lon);
+console.log(`Shortcut distance: ${shortcutDist.toFixed(0)}m, bearing: ${shortcutBearing.toFixed(1)}°`);
+
+// Dwell at stop 6
+emitStatic(stop6.lat, stop6.lon, shortcutBearing, STOP_DWELL_S);
+groundTruth.push({ stop_idx: stopSeqIdx, lat: stop6.lat, lon: stop6.lon, timestamp: ts - STOP_DWELL_S, phase: 'stop_6', event: 'departure_shortcut' });
+
+// Travel shortcut (off-route!)
+let traveled = 0;
+let speedMs = CRUISE_MS * 0.4;
+const offRouteStartTS = ts;
+
+while (traveled < shortcutDist) {
+  const targetMs = CRUISE_MS;
+  if (speedMs < targetMs) speedMs = Math.min(speedMs + ACCEL_MS2, targetMs);
+  else speedMs = Math.max(speedMs - DECEL_MS2, targetMs);
+
+  const step = Math.min(speedMs, shortcutDist - traveled);
+  traveled += step;
+
+  const frac = traveled / shortcutDist;
+  const lat = stop6.lat + (stop10.lat - stop6.lat) * frac;
+  const lon = stop6.lon + (stop10.lon - stop6.lon) * frac;
+  emitGPS(lat, lon, speedMs, shortcutBearing);
+}
+
+const offRouteDuration = ts - offRouteStartTS;
+console.log(`Off-route duration: ${offRouteDuration}s (expected to trigger off-route detection)`);
+
+// Phase 3: Re-acquire at stop 10, continue to stop 13
+console.log('\\nPhase 3: Re-acquire at Stop 10, continue to Stop 13');
+groundTruth.push({ stop_idx: stopSeqIdx, lat: stop10.lat, lon: stop10.lon, timestamp: ts, phase: 'stop_10', event: 're_acquisition', off_route_duration_s: offRouteDuration });
+
+// Dwell at stop 10
+emitStatic(stop10.lat, stop10.lon, segments[stopSegments[5]].bearing, STOP_DWELL_S);
+stopSeqIdx++;
+
+// Continue from stop 10 to stop 13
+for (let segIdx = stopSegments[5]; segIdx < segments.length; segIdx++) {
+  const seg = segments[segIdx];
+
+  // Travel segment
+  let traveled = 0;
+  let speedMs = CRUISE_MS * 0.4;
+  while (traveled < seg.dist) {
+    const targetMs = CRUISE_MS;
+    if (speedMs < targetMs) speedMs = Math.min(speedMs + ACCEL_MS2, targetMs);
+    else speedMs = Math.max(speedMs - DECEL_MS2, targetMs);
+
+    const step = Math.min(speedMs, seg.dist - traveled);
+    traveled += step;
+
+    const frac = traveled / seg.dist;
+    const lat = seg.from[0] + (seg.to[0] - seg.from[0]) * frac;
+    const lon = seg.from[1] + (seg.to[1] - seg.from[1]) * frac;
+    emitGPS(lat, lon, speedMs, seg.bearing);
+  }
+
+  // Check if we're at a stop
+  for (let s = 6; s < stops.length; s++) {
+    if (segIdx === stopSegments[s]) {
+      emitStatic(seg.to[0], seg.to[1], seg.bearing, STOP_DWELL_S);
+      groundTruth.push({ stop_idx: stopSeqIdx, seg_idx: segIdx, phase: 'normal_after_stop10' });
+      stopSeqIdx++;
+    }
+  }
+}
+
+// Write outputs
+const outNmea = process.argv[3] || '../test_data/ty225_shortcut.nmea';
+const outGt = process.argv[4] || '../test_data/ty225_shortcut_gt.json';
+const outTrace = process.argv[5] || '../test_data/ty225_shortcut_trace.jsonl';
+
+fs.writeFileSync(outNmea, nmeaLines.join('\n') + '\n');
+console.log(`\\nWrote ${nmeaLines.length} NMEA lines to ${outNmea}`);
+
+fs.writeFileSync(outGt, JSON.stringify(groundTruth, null, 2));
+console.log(`Wrote ground truth to ${outGt}`);
+
+fs.writeFileSync(outTrace, trace.map(line => JSON.stringify(line)).join('\n') + '\n');
+console.log(`Wrote trace to ${outTrace}`);
+
+console.log(`\\nSimulation summary:`);
+console.log(`  - Total GPS points: ${nmeaLines.length / 2}`);
+console.log(`  - Off-route duration: ${offRouteDuration}s`);
+console.log(`  - Expected behavior: Off-route detected at 5s, position frozen, recovery on re-acquisition`);


### PR DESCRIPTION
## Summary
Implements off-route detection to handle sustained GPS conditions where the signal is present but consistently doesn't fit route geometry. This addresses issue E7 "Recovery Triggers Cannot Fire Even If Wired Up" by detecting when GPS drifts >50m from route for 5+ seconds and triggering position freezing with recovery on re-acquisition.

## Problem
The current system handles GPS outages and noise spikes, but cannot detect sustained off-route conditions where:
- Deep urban canyon with multipath causes GPS drift away from road
- Bus physically deviated (detour, depot, wrong route loaded)

Without off-route detection, the system would continue processing invalid GPS positions, potentially leading to:
- Incorrect arrival detection
- DR position corruption
- Stale stop indices

## Solution
Adds hysteresis-based off-route detection with:
- **5 ticks to confirm** off-route (prevents false positives from transient multipath)
- **2 ticks to clear** off-route (fast re-acquisition)
- **Position freezing** during off-route (DR doesn't advance)
- **Recovery on re-acquisition** (stop indices re-synchronized)

## Changes

### Core Detection (kalman.rs)
- Added `OFF_ROUTE_D2_THRESHOLD = 25_000_000` (50m²)
- Added `OFF_ROUTE_CONFIRM_TICKS = 5` and `OFF_ROUTE_CLEAR_TICKS = 2`
- Implemented detection in `process_gps_update()` using map matching distance²
- Reset counters in `handle_outage()` to prevent immediate re-trigger
- Disabled during warmup (first 3 ticks) to prevent false triggers

### State Machine (state.rs)
- Added `needs_recovery_on_reacquisition: bool` flag
- Added `off_route_freeze_time: Option<u64>` for elapsed time calculation
- Handle `ProcessResult::OffRoute` by freezing position and suspending detection
- Implement re-acquisition recovery using existing `recovery::find_stop_index()`

### Map Matching (map_match.rs)
- Changed `find_best_segment_restricted()` return type to `(usize, i64)`
- Returns both segment index and pure distance² (without heading penalty)

### Types (shared/src/lib.rs)
- Added `off_route_suspect_ticks: u8` and `off_route_clear_ticks: u8` to `KalmanState`
- Added `ProcessResult::OffRoute { last_valid_s, last_valid_v }` variant

### Output (output.rs)
- Added `OffRoute` variant to JSON serialization

## Testing

### Unit Tests (test_off_route_detection.rs)
- `test_off_route_confirms_after_5_ticks` - Confirms at exactly 5 ticks
- `test_off_route_no_trigger_before_5_ticks` - No trigger at 4 ticks
- `test_off_route_hysteresis_partial_clear` - 5 to confirm, 2 to clear
- `test_off_route_counter_resets_on_outage` - Outage clears state
- `test_off_route_disabled_during_warmup` - Detection disabled during warmup

### Integration Tests (test_off_route_integration.rs)
- `test_off_route_freezes_position` - Position frozen during off-route
- `test_re_acquisition_runs_recovery` - Recovery triggered on return
- `test_full_off_route_cycle` - Complete cycle: Normal → OffRoute → Re-acquisition → Normal

All 35 pico2-firmware tests pass. All gps_processor tests pass.

## Limitations
- Cannot detect along-route drift (GPS stays on road but advances faster than bus)
- Single GPS sensor cannot distinguish urban canyon vs physical deviation
- These are fundamental limitations, not implementation bugs

## Related Issues
- Fixes #1 (E7 - Recovery Triggers Cannot Fire Even If Wired Up)
- Code Review: docs/claude_review.md
- Design: docs/superpowers/specs/2026-04-14-off-route-detection-design.md

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>