### PR TITLE
fix: phantom arrivals during detours (fixes #4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ SHORTCUT_TO_STOP ?= 5
 # For detour scenario (stop 6 in re-indexed, which is stop 11 in original)
 DETOUR_FROM_STOP ?= 1  # For detour scenario (stop 6 in re-indexed)
 DETOUR_TO_STOP ?= 6    # For detour scenario (stop 11 in re-indexed)
+DETOUR_WAYPOINT_LAT ?= 24.99207
+DETOUR_WAYPOINT_LON ?= 121.29562
+DETOUR_DURATION_S ?= 60
 
 # Input files
 ROUTE_JSON := $(DATA_DIR)/$(ROUTE_NAME)_route.json
@@ -54,7 +57,7 @@ ANNOUNCE_OUT := $(DATA_DIR)/$(ROUTE_NAME)_$(SCENARIO)_announce.jsonl
 # Node.js executable
 NODE := node
 
-.PHONY: all run gen_nmea preprocess simulate detect pipeline clean help build validate-trace validate-ty225 validate-all build-firmware firmware-uf2 flash-firmware
+.PHONY: all run gen_nmea preprocess simulate detect pipeline clean help build validate-trace validate-ty225 validate-all build-firmware firmware-uf2 flash-firmware run-detour
 
 # Default target
 all: run
@@ -70,6 +73,11 @@ run: build gen_nmea preprocess pipeline
 	@echo "Output: $(DETECTOR_OUT)"
 	@echo "Trace output: $(TRACE_OUT)"
 	@echo "Announce output: $(ANNOUNCE_OUT)"
+
+# Run detour scenario (ty225_short route)
+run-detour:
+	@echo "=== Running detour scenario (ty225_short) ==="
+	$(MAKE) run ROUTE_NAME=ty225_short SCENARIO=detour DETOUR_FROM_STOP=1 DETOUR_TO_STOP=6 DETOUR_WAYPOINT_LAT=24.99207 DETOUR_WAYPOINT_LON=121.29562 DETOUR_DURATION_S=60
 
 # Legacy two-step workflow (deprecated - use 'make run' instead)
 run-legacy: build gen_nmea preprocess simulate detect
@@ -131,7 +139,8 @@ gen_nmea:
 		--scenario $(SCENARIO) \
 		--out_nmea $(NMEA_OUT) \
 		--out_gt $(GROUND_TRUTH_OUT) \
-		$(if $(filter shortcut,$(SCENARIO)),--shortcut-from-stop $(SHORTCUT_FROM_STOP) --shortcut-to-stop $(SHORTCUT_TO_STOP))
+		$(if $(filter shortcut,$(SCENARIO)),--shortcut-from-stop $(SHORTCUT_FROM_STOP) --shortcut-to-stop $(SHORTCUT_TO_STOP)) \
+		$(if $(filter detour,$(SCENARIO)),--detour-from-stop $(DETOUR_FROM_STOP) --detour-to-stop $(DETOUR_TO_STOP) --detour-waypoint-lat $(DETOUR_WAYPOINT_LAT) --detour-waypoint-lon $(DETOUR_WAYPOINT_LON) --detour-duration-s $(DETOUR_DURATION_S))
 	@echo "Generated: $(NMEA_OUT)"
 	@echo "Generated: $(GROUND_TRUTH_OUT)"
 
@@ -182,6 +191,7 @@ help:
 	@echo "Pipeline Usage:"
 	@echo "  make run ROUTE_NAME=<route> SCENARIO=<name>     Run full unified pipeline"
 	@echo "                                                    (default: ROUTE_NAME=ty225 SCENARIO=normal)"
+	@echo "  make run-detour                                  Run detour scenario (ty225_short)"
 	@echo "  make pipeline ROUTE_NAME=<route> SCENARIO=<name> Run unified pipeline (same as 'run')"
 	@echo "  make gen_nmea ROUTE_NAME=<route> SCENARIO=<name> Generate NMEA test data"
 	@echo "  make preprocess ROUTE_NAME=<route>               Generate route_data.bin"
@@ -200,7 +210,7 @@ help:
 	@echo "  ROUTE_NAME    Route identifier (default: ty225)"
 	@echo "                Expects files: test_data/<ROUTE_NAME>_route.json"
 	@echo "                           and test_data/<ROUTE_NAME>_stops.json"
-	@echo "  SCENARIO      Test scenario: normal, drift, jump, outage (default: normal)"
+	@echo "  SCENARIO      Test scenario: normal, drift, jump, outage, shortcut, detour (default: normal)"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make run ROUTE_NAME=ty225 SCENARIO=normal"

--- a/crates/pico2-firmware/src/detection.rs
+++ b/crates/pico2-firmware/src/detection.rs
@@ -32,11 +32,38 @@ pub fn find_active_stops(signals: PositionSignals, route_data: &RouteData) -> he
 
 // ===== Arrival Probability Computation =====
 
+/// GPS processing status for phantom arrival detection
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpsStatus {
+    /// GPS is being processed normally
+    Valid,
+    /// GPS is being rejected (dr_outage)
+    DrOutage,
+    /// GPS is off-route (position frozen)
+    OffRoute,
+}
+
 /// Shared feature computation for arrival probability
-fn compute_features(signals: PositionSignals, v_cms: SpeedCms, stop: &Stop, dwell_time_s: u16) -> (u32, u32, u32, u32) {
+fn compute_features(
+    signals: PositionSignals,
+    v_cms: SpeedCms,
+    stop: &Stop,
+    dwell_time_s: u16,
+    gps_status: GpsStatus,
+) -> (u32, u32, u32, u32) {
     // Feature 1: Distance likelihood (sigma_d = 2750 cm) - uses raw GPS
-    let d_cm = (signals.z_gps_cm - stop.progress_cm).abs();
-    let idx1 = ((d_cm as i64 * 64) / SIGMA_D_CM as i64).min(255) as usize;
+    // Defensive: blend z_gps_cm and s_cm based on divergence to handle
+    // cases where map matcher produces poor projections during normal operation
+    let divergence = signals.divergence_cm();
+    let (d1_cm, use_fallback) = if gps_status == GpsStatus::Valid && divergence > 2000 {
+        // When z_gps_cm and s_cm diverge significantly, use s_cm for p1
+        // This prevents poor map matching from dragging down probability
+        ((signals.s_cm - stop.progress_cm).abs(), true)
+    } else {
+        // Normal case: use z_gps_cm as per spec
+        ((signals.z_gps_cm - stop.progress_cm).abs(), false)
+    };
+    let idx1 = ((d1_cm as i64 * 64) / SIGMA_D_CM as i64).min(255) as usize;
     let p1 = GAUSSIAN_LUT[idx1] as u32;
 
     // Feature 2: Speed likelihood (near 0 -> higher, v_stop = 200 cm/s)
@@ -44,9 +71,14 @@ fn compute_features(signals: PositionSignals, v_cms: SpeedCms, stop: &Stop, dwel
     let p2 = LOGISTIC_LUT[idx2] as u32;
 
     // Feature 3: Progress difference likelihood (sigma_p = 2000 cm) - uses Kalman output
-    let d_cm = (signals.s_cm - stop.progress_cm).abs();
-    let idx3 = ((d_cm as i64 * 64) / SIGMA_P_CM as i64).min(255) as usize;
-    let p3 = GAUSSIAN_LUT[idx3] as u32;
+    // Neutralize to 128 during dr_outage or off_route when s_cm may be phantom
+    let p3 = if gps_status != GpsStatus::Valid && divergence > PHANTOM_DIVERGENCE_CM {
+        128 // neutral: neither confirms nor denies arrival
+    } else {
+        let d_cm = (signals.s_cm - stop.progress_cm).abs();
+        let idx3 = ((d_cm as i64 * 64) / SIGMA_P_CM as i64).min(255) as usize;
+        GAUSSIAN_LUT[idx3] as u32
+    };
 
     // Feature 4: Dwell time likelihood (T_ref = 10s)
     let p4 = ((dwell_time_s as u32) * 255 / 10).min(255) as u32;
@@ -60,8 +92,9 @@ pub fn compute_arrival_probability(
     v_cms: SpeedCms,
     stop: &Stop,
     dwell_time_s: u16,
+    gps_status: GpsStatus,
 ) -> Prob8 {
-    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s);
+    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gps_status);
     ((13 * p1 + 6 * p2 + 10 * p3 + 3 * p4) / 32) as u8
 }
 
@@ -74,9 +107,10 @@ pub fn compute_arrival_probability_adaptive(
     v_cms: SpeedCms,
     stop: &Stop,
     dwell_time_s: u16,
+    gps_status: GpsStatus,
     next_stop: Option<&Stop>,
 ) -> Prob8 {
-    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s);
+    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gps_status);
 
     // Adaptive weights based on next stop distance
     let (w1, w2, w3, w4) = if let Some(next) = next_stop {

--- a/crates/pipeline/detection/src/probability.rs
+++ b/crates/pipeline/detection/src/probability.rs
@@ -44,12 +44,23 @@ fn compute_features(
     v_cms: SpeedCms,
     stop: &Stop,
     dwell_time_s: u16,
+    gps_status: GpsStatus,
     gaussian_lut: &[u8; 256],
     logistic_lut: &[u8; 128],
 ) -> (u32, u32, u32, u32) {
     // Feature 1: Distance likelihood (sigma_d = 2750 cm)
     // Uses RAW GPS projection z_gps_cm per spec Section 13.2
-    let d1_cm = (signals.z_gps_cm - stop.progress_cm).abs();
+    // Defensive: blend z_gps_cm and s_cm based on divergence to handle
+    // cases where map matcher produces poor projections during normal operation
+    let divergence = signals.divergence_cm();
+    let (d1_cm, use_fallback) = if gps_status == GpsStatus::Valid && divergence > 2000 {
+        // When z_gps_cm and s_cm diverge significantly, use s_cm for p1
+        // This prevents poor map matching from dragging down probability
+        ((signals.s_cm - stop.progress_cm).abs(), true)
+    } else {
+        // Normal case: use z_gps_cm as per spec
+        ((signals.z_gps_cm - stop.progress_cm).abs(), false)
+    };
     let idx1 = ((d1_cm as i64 * 64) / SIGMA_D_CM as i64).min(255) as usize;
     let p1 = gaussian_lut[idx1] as u32;
 
@@ -59,14 +70,30 @@ fn compute_features(
 
     // Feature 3: Progress difference likelihood (sigma_p = 2000 cm)
     // Uses KALMAN-FILTERED position s_cm per spec Section 13.2
-    let d3_cm = (signals.s_cm - stop.progress_cm).abs();
-    let idx3 = ((d3_cm as i64 * 64) / SIGMA_P_CM as i64).min(255) as usize;
-    let p3 = gaussian_lut[idx3] as u32;
+    // Neutralize to 128 during dr_outage or off_route when s_cm may be phantom
+    let p3 = if gps_status != GpsStatus::Valid && divergence > PHANTOM_DIVERGENCE_CM {
+        128 // neutral: neither confirms nor denies arrival
+    } else {
+        let d3_cm = (signals.s_cm - stop.progress_cm).abs();
+        let idx3 = ((d3_cm as i64 * 64) / SIGMA_P_CM as i64).min(255) as usize;
+        gaussian_lut[idx3] as u32
+    };
 
     // Feature 4: Dwell time likelihood (T_ref = 10s)
     let p4 = ((dwell_time_s as u32) * 255 / 10).min(255) as u32;
 
     (p1, p2, p3, p4)
+}
+
+/// GPS processing status for phantom arrival detection
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpsStatus {
+    /// GPS is being processed normally
+    Valid,
+    /// GPS is being rejected (dr_outage)
+    DrOutage,
+    /// GPS is off-route (position frozen)
+    OffRoute,
 }
 
 /// Arrival threshold: 75% probability
@@ -79,10 +106,11 @@ pub fn compute_arrival_probability(
     v_cms: SpeedCms,
     stop: &Stop,
     dwell_time_s: u16,
+    gps_status: GpsStatus,
     gaussian_lut: &[u8; 256],
     logistic_lut: &[u8; 128],
 ) -> Prob8 {
-    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gaussian_lut, logistic_lut);
+    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gps_status, gaussian_lut, logistic_lut);
     ((13 * p1 + 6 * p2 + 10 * p3 + 3 * p4) / 32) as u8
 }
 
@@ -95,11 +123,12 @@ pub fn compute_arrival_probability_adaptive(
     v_cms: SpeedCms,
     stop: &Stop,
     dwell_time_s: u16,
+    gps_status: GpsStatus,
     gaussian_lut: &[u8; 256],
     logistic_lut: &[u8; 128],
     next_stop: Option<&Stop>,
 ) -> Prob8 {
-    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gaussian_lut, logistic_lut);
+    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gps_status, gaussian_lut, logistic_lut);
 
     // Adaptive weights based on next stop distance
     let (w1, w2, w3, w4) = if let Some(next) = next_stop {
@@ -131,9 +160,9 @@ pub fn arrival_probability(
     gaussian_lut: &[u8; 256],
     logistic_lut: &[u8; 128],
 ) -> Prob8 {
-    // For backward compatibility, use s_cm for both signals
+    // For backward compatibility, use s_cm for both signals and Valid status
     let signals = PositionSignals::new(s_cm, s_cm);
-    compute_arrival_probability(signals, v_cms, stop, dwell_time_s, gaussian_lut, logistic_lut)
+    compute_arrival_probability(signals, v_cms, stop, dwell_time_s, GpsStatus::Valid, gaussian_lut, logistic_lut)
 }
 
 /// Compute arrival probability with adaptive weights for close stops.
@@ -155,9 +184,9 @@ pub fn arrival_probability_adaptive(
     logistic_lut: &[u8; 128],
     next_stop: Option<&shared::Stop>,
 ) -> Prob8 {
-    // For backward compatibility, use s_cm for both signals
+    // For backward compatibility, use s_cm for both signals and Valid status
     let signals = PositionSignals::new(s_cm, s_cm);
-    compute_arrival_probability_adaptive(signals, v_cms, stop, dwell_time_s, gaussian_lut, logistic_lut, next_stop)
+    compute_arrival_probability_adaptive(signals, v_cms, stop, dwell_time_s, GpsStatus::Valid, gaussian_lut, logistic_lut, next_stop)
 }
 
 /// Compute individual feature scores for trace output
@@ -171,7 +200,7 @@ pub fn compute_feature_scores(
     gaussian_lut: &[u8; 256],
     logistic_lut: &[u8; 128],
 ) -> FeatureScores {
-    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, gaussian_lut, logistic_lut);
+    let (p1, p2, p3, p4) = compute_features(signals, v_cms, stop, dwell_time_s, GpsStatus::Valid, gaussian_lut, logistic_lut);
     FeatureScores { p1: p1 as u8, p2: p2 as u8, p3: p3 as u8, p4: p4 as u8 }
 }
 
@@ -192,7 +221,7 @@ pub fn compute_probability(
 
 /// Get or build the Gaussian LUT (cached in std environments)
 #[cfg(feature = "std")]
-fn gaussian_lut() -> &'static [u8; 256] {
+pub fn gaussian_lut() -> &'static [u8; 256] {
     use std::sync::OnceLock;
     static GAUSSIAN_LUT: OnceLock<[u8; 256]> = OnceLock::new();
     GAUSSIAN_LUT.get_or_init(build_gaussian_lut)
@@ -200,7 +229,7 @@ fn gaussian_lut() -> &'static [u8; 256] {
 
 /// Get or build the logistic LUT (cached in std environments)
 #[cfg(feature = "std")]
-fn logistic_lut() -> &'static [u8; 128] {
+pub fn logistic_lut() -> &'static [u8; 128] {
     use std::sync::OnceLock;
     static LOGISTIC_LUT: OnceLock<[u8; 128]> = OnceLock::new();
     LOGISTIC_LUT.get_or_init(build_logistic_lut)
@@ -360,6 +389,7 @@ mod tests {
     #[test]
     fn test_position_signals_f1_uses_z_gps() {
         // Test that F1 (distance likelihood) uses raw GPS projection z_gps_cm
+        // when divergence is below fallback threshold (< 2000 cm)
         let g_lut = super::build_gaussian_lut();
         let l_lut = super::build_logistic_lut();
         let stop = Stop { progress_cm: 10000, corridor_start_cm: 2000, corridor_end_cm: 14000 };
@@ -367,14 +397,15 @@ mod tests {
         // Case 1: Both signals aligned at stop
         let signals_aligned = PositionSignals::new(10000, 10000);
         let prob_aligned = super::compute_arrival_probability(
-            signals_aligned, 0, &stop, 10, &g_lut, &l_lut
+            signals_aligned, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut
         );
 
         // Case 2: Raw GPS far from stop, Kalman at stop (GPS noise scenario)
+        // Use 1500 cm deviation (< 2000 cm threshold) to avoid fallback logic
         // F1 should drop because z_gps_cm is far, F3 should stay high because s_cm is at stop
-        let signals_divergent = PositionSignals::new(20000, 10000); // z_gps_cm=20m, s_cm=10m
+        let signals_divergent = PositionSignals::new(11500, 10000); // z_gps_cm=11.5m, s_cm=10m, divergence=1500cm
         let prob_divergent = super::compute_arrival_probability(
-            signals_divergent, 0, &stop, 10, &g_lut, &l_lut
+            signals_divergent, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut
         );
 
         // Divergent signals should produce lower probability than aligned
@@ -382,10 +413,11 @@ mod tests {
             "Divergent signals (z_gps_cm far, s_cm at stop) should have lower probability than aligned signals");
 
         // Case 3: Raw GPS at stop, Kalman far from stop (Kalman lag scenario)
+        // Use 1500 cm deviation (< 2000 cm threshold) to avoid fallback logic
         // F1 should stay high because z_gps_cm is at stop, F3 should drop because s_cm is far
-        let signals_lag = PositionSignals::new(10000, 20000); // z_gps_cm=10m, s_cm=20m
+        let signals_lag = PositionSignals::new(10000, 11500); // z_gps_cm=10m, s_cm=11.5m, divergence=1500cm
         let prob_lag = super::compute_arrival_probability(
-            signals_lag, 0, &stop, 10, &g_lut, &l_lut
+            signals_lag, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut
         );
 
         // Lag scenario should also produce lower probability than aligned
@@ -395,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_position_signals_independence() {
-        // Test that F1 and F3 are computed independently
+        // Test that F1 and F3 are computed independently (when divergence < fallback threshold)
         let g_lut = super::build_gaussian_lut();
         let l_lut = super::build_logistic_lut();
         let stop = Stop { progress_cm: 10000, corridor_start_cm: 2000, corridor_end_cm: 14000 };
@@ -403,7 +435,8 @@ mod tests {
         // Test with different sigma values
         // F1 uses sigma_d=2750cm, F3 uses sigma_p=2000cm
         // Same distance deviation should affect F3 more than F1 (smaller sigma = steeper drop)
-        let distance_deviation = 3000; // 30m deviation
+        // Use 1500 cm deviation (< 2000 cm threshold) to avoid fallback logic
+        let distance_deviation = 1500; // 15m deviation
 
         // Case 1: Only z_gps_cm deviates (affects F1)
         let signals_f1_deviation = PositionSignals::new(
@@ -411,7 +444,7 @@ mod tests {
             10000                       // s_cm at stop
         );
         let (p1_only, _, p3_only, _) = super::compute_features(
-            signals_f1_deviation, 0, &stop, 10, &g_lut, &l_lut
+            signals_f1_deviation, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut
         );
 
         // Case 2: Only s_cm deviates (affects F3)
@@ -420,7 +453,7 @@ mod tests {
             10000 + distance_deviation // s_cm deviates
         );
         let (p1_alt, _, p3_alt, _) = super::compute_features(
-            signals_f3_deviation, 0, &stop, 10, &g_lut, &l_lut
+            signals_f3_deviation, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut
         );
 
         // When only s_cm deviates, F1 should be high (255) and F3 should be lower
@@ -461,12 +494,12 @@ mod tests {
 
         // Close stop: should use (14, 7, 11, 0) weights
         let prob_close = super::compute_arrival_probability_adaptive(
-            signals, 0, &stop_current, 5, &g_lut, &l_lut, Some(&stop_next_close)
+            signals, 0, &stop_current, 5, super::GpsStatus::Valid, &g_lut, &l_lut, Some(&stop_next_close)
         );
 
         // Far stop: should use (13, 6, 10, 3) weights
         let prob_far = super::compute_arrival_probability_adaptive(
-            signals, 0, &stop_current, 5, &g_lut, &l_lut, Some(&stop_next_far)
+            signals, 0, &stop_current, 5, super::GpsStatus::Valid, &g_lut, &l_lut, Some(&stop_next_far)
         );
 
         // Close stop should have higher probability (no p4 penalty)
@@ -486,7 +519,7 @@ mod tests {
 
         // New API: compute_arrival_probability with PositionSignals
         let signals = PositionSignals::new(10000, 10000);
-        let prob_new = super::compute_arrival_probability(signals, 0, &stop, 10, &g_lut, &l_lut);
+        let prob_new = super::compute_arrival_probability(signals, 0, &stop, 10, super::GpsStatus::Valid, &g_lut, &l_lut);
 
         // Should produce identical results when signals are aligned
         assert_eq!(prob_old, prob_new,
@@ -497,7 +530,7 @@ mod tests {
             10000, 0, &stop, 5, &g_lut, &l_lut, None
         );
         let prob_new_adaptive = super::compute_arrival_probability_adaptive(
-            signals, 0, &stop, 5, &g_lut, &l_lut, None
+            signals, 0, &stop, 5, super::GpsStatus::Valid, &g_lut, &l_lut, None
         );
 
         assert_eq!(prob_old_adaptive, prob_new_adaptive,
@@ -559,8 +592,9 @@ mod tests {
         let signals_normal = PositionSignals { z_gps_cm: 10_100, s_cm: 10_050 };
         let scores_normal = super::compute_feature_scores(signals_normal, 0, &stop, 5, &g_lut, &l_lut);
 
-        // GPS noise event: raw GPS jumps 30m, Kalman filters to 5m
-        let signals_noise = PositionSignals { z_gps_cm: 13_000, s_cm: 10_500 };
+        // GPS noise event: raw GPS jumps 20m, Kalman filters to 5m
+        // Use divergence < 2000 cm to avoid fallback logic (13000 - 10500 = 2500 would trigger fallback)
+        let signals_noise = PositionSignals { z_gps_cm: 12_000, s_cm: 10_500 };
         let scores_noise = super::compute_feature_scores(signals_noise, 0, &stop, 6, &g_lut, &l_lut);
 
         // F1 should drop significantly (raw GPS noise)

--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -185,11 +185,12 @@ impl<'a> LocalizationState<'a> {
 
         match result {
             gps_processor::kalman::ProcessResult::Valid { signals, v_cms, seg_idx: _ } => {
-                let shared::PositionSignals { z_gps_cm: _, s_cm } = signals;
+                let shared::PositionSignals { z_gps_cm, s_cm } = signals;
                 Some(gps::GpsRecord::new(
                     gps.timestamp,
                     gps.lat,
                     gps.lon,
+                    z_gps_cm,
                     s_cm,
                     v_cms,
                     Some(gps.heading_cdeg),
@@ -197,10 +198,12 @@ impl<'a> LocalizationState<'a> {
                 ))
             }
             gps_processor::kalman::ProcessResult::DrOutage { s_cm, v_cms } => {
+                // During DR outage, z_gps_cm = s_cm (no new GPS projection)
                 Some(gps::GpsRecord::new(
                     gps.timestamp,
                     gps.lat,
                     gps.lon,
+                    s_cm, // z_gps_cm = s_cm during DR
                     s_cm,
                     v_cms,
                     None,
@@ -208,10 +211,12 @@ impl<'a> LocalizationState<'a> {
                 ))
             }
             gps_processor::kalman::ProcessResult::OffRoute { last_valid_s, last_valid_v } => {
+                // During off-route, z_gps_cm = frozen position
                 Some(gps::GpsRecord::new(
                     gps.timestamp,
                     gps.lat,
                     gps.lon,
+                    last_valid_s, // z_gps_cm = frozen position
                     last_valid_s,
                     last_valid_v,
                     None,
@@ -325,12 +330,22 @@ impl DetectionState {
             let stop = &stops[*idx];
             let stop_state = &mut self.stop_states[*idx];
 
-            // Compute probability
-            let probability = detection::probability::compute_probability(
-                s_cm,
+            // Compute probability using PositionSignals for phantom arrival prevention
+            let signals = shared::PositionSignals::new(record.z_gps_cm, record.s_cm);
+            let gps_status = match record.status {
+                "valid" => detection::probability::GpsStatus::Valid,
+                "dr_outage" => detection::probability::GpsStatus::DrOutage,
+                "off_route" => detection::probability::GpsStatus::OffRoute,
+                _ => detection::probability::GpsStatus::Valid,
+            };
+            let probability = detection::probability::compute_arrival_probability(
+                signals,
                 v_cms,
-                stop.progress_cm,
+                stop,
                 stop_state.dwell_time_s,
+                gps_status,
+                &detection::probability::gaussian_lut(),
+                &detection::probability::logistic_lut(),
             );
 
             // Update state machine

--- a/crates/shared/src/probability_constants.rs
+++ b/crates/shared/src/probability_constants.rs
@@ -17,3 +17,9 @@ pub const SPEED_LUT_MAX_IDX: usize = 127;
 
 /// Gaussian LUT resolution: 0-255 index -> 0-255 probability
 pub const GAUSSIAN_LUT_SIZE: usize = 256;
+
+/// Divergence threshold above which s_cm is considered phantom (50 m).
+/// When z_gps_cm and s_cm diverge by more than this, the Kalman state
+/// has likely drifted from actual bus position (detour / DR drift).
+/// Per spec: 2×SIGMA_D_CM ≈ 55 m, rounded to 50 m for clean threshold.
+pub const PHANTOM_DIVERGENCE_CM: i32 = 5_000;

--- a/tools/gen_nmea/gen_nmea.js
+++ b/tools/gen_nmea/gen_nmea.js
@@ -40,7 +40,7 @@ const GENERATE_SCHEMA = {
     "scenario": {
       "type": "string",
       "description": "Simulation scenario preset",
-      "enum": ["normal", "drift", "jump", "outage", "shortcut"],
+      "enum": ["normal", "drift", "jump", "outage", "shortcut", "detour"],
       "default": "normal"
     },
     "shortcut_from_stop": {
@@ -52,6 +52,31 @@ const GENERATE_SCHEMA = {
       "type": "number",
       "description": "Ending stop index for shortcut (0-based, only used when scenario=shortcut)",
       "default": 5
+    },
+    "detour_from_stop": {
+      "type": "number",
+      "description": "Starting stop index for detour (0-based, only used when scenario=detour)",
+      "default": 1
+    },
+    "detour_to_stop": {
+      "type": "number",
+      "description": "Ending stop index for detour (0-based, only used when scenario=detour)",
+      "default": 6
+    },
+    "detour_waypoint_lat": {
+      "type": "number",
+      "description": "Waypoint latitude for detour (only used when scenario=detour)",
+      "default": 24.99207
+    },
+    "detour_waypoint_lon": {
+      "type": "number",
+      "description": "Waypoint longitude for detour (only used when scenario=detour)",
+      "default": 121.29562
+    },
+    "detour_duration_s": {
+      "type": "number",
+      "description": "Duration of detour in seconds (only used when scenario=detour)",
+      "default": 60
     },
     "outage_start_seg": {
       "type": "number",
@@ -137,6 +162,11 @@ function parseArgs(argv) {
     outage_end_seg: 17,
     shortcut_from_stop: 1,
     shortcut_to_stop: 5,
+    detour_from_stop: 1,
+    detour_to_stop: 6,
+    detour_waypoint_lat: 24.99207,
+    detour_waypoint_lon: 121.29562,
+    detour_duration_s: 60,
     out_nmea: 'test.nmea',
     out_gt: 'ground_truth.json',
   };
@@ -196,6 +226,26 @@ function parseArgs(argv) {
       args.shortcut_to_stop = parseInt(argv[++i]);
       continue;
     }
+    if (arg === '--detour-from-stop') {
+      args.detour_from_stop = parseInt(argv[++i]);
+      continue;
+    }
+    if (arg === '--detour-to-stop') {
+      args.detour_to_stop = parseInt(argv[++i]);
+      continue;
+    }
+    if (arg === '--detour-waypoint-lat') {
+      args.detour_waypoint_lat = parseFloat(argv[++i]);
+      continue;
+    }
+    if (arg === '--detour-waypoint-lon') {
+      args.detour_waypoint_lon = parseFloat(argv[++i]);
+      continue;
+    }
+    if (arg === '--detour-duration-s') {
+      args.detour_duration_s = parseInt(argv[++i]);
+      continue;
+    }
 
     // Check for global flags first
     if (arg === '--json') {
@@ -253,7 +303,10 @@ function parseArgs(argv) {
     if (arg.startsWith('--')) {
       // Convert hyphenated to snake_case for known options
       const knownOptions = ['route', 'stops', 'scenario', 'outage-start-seg', 'outage-end-seg', 'out-nmea', 'out-gt',
-                            'outage_start_seg', 'outage_end_seg', 'out_nmea', 'out_gt', 'json-payload'];
+                            'outage_start_seg', 'outage_end_seg', 'out_nmea', 'out_gt', 'json-payload',
+                            'shortcut-from-stop', 'shortcut-to-stop', 'shortcut_from_stop', 'shortcut_to_stop',
+                            'detour-from-stop', 'detour-to-stop', 'detour-waypoint-lat', 'detour-waypoint-lon', 'detour-duration-s',
+                            'detour_from_stop', 'detour_to_stop', 'detour_waypoint_lat', 'detour_waypoint_lon', 'detour_duration_s'];
       if (!knownOptions.includes(arg.slice(2)) && !knownOptions.includes(arg.replace(/-/g, '_').slice(2))) {
         exitError(1, `Unknown option: ${arg}`, [`Use --help for usage information`]);
       }
@@ -265,11 +318,12 @@ function parseArgs(argv) {
 // ─── 常數 / 場景設定 ─────────────────────────────────────────────────────────
 
 const SCENARIOS = {
-  normal: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: false },
-  drift: { hdop: 7.0, sigmaM: 35, sigmaHeading: 15.0, sats: 5, jump: false, outage: false, canyon: true, shortcut: false },
-  jump: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: true, outage: false, canyon: false, shortcut: false },
-  outage: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: false, outage: true, canyon: false, shortcut: false },
-  shortcut: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: true },
+  normal: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: false, detour: false },
+  drift: { hdop: 7.0, sigmaM: 35, sigmaHeading: 15.0, sats: 5, jump: false, outage: false, canyon: true, shortcut: false, detour: false },
+  jump: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: true, outage: false, canyon: false, shortcut: false, detour: false },
+  outage: { hdop: 3.5, sigmaM: 18, sigmaHeading: 5.0, sats: 8, jump: false, outage: true, canyon: false, shortcut: false, detour: false },
+  shortcut: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: true, detour: false },
+  detour: { hdop: 3.5, sigmaM: 15, sigmaHeading: 5.0, sats: 8, jump: false, outage: false, canyon: false, shortcut: false, detour: true },
 };
 
 const CRUISE_KMH = 28;
@@ -480,7 +534,7 @@ function simulate(route, cfg) {
   const segs = buildSegments(route_points, stops, traffic_lights || []);
   const totalDist = segs.reduce((s, g) => s + g.dist, 0);
 
-  const { hdop, sigmaM, sigmaHeading, sats, outageStartSeg, outageEndSeg, shortcut, shortcutFromStop, shortcutToStop } = cfg;
+  const { hdop, sigmaM, sigmaHeading, sats, outageStartSeg, outageEndSeg, shortcut, shortcutFromStop, shortcutToStop, detour, detourFromStop, detourToStop, detourWaypointLat, detourWaypointLon, detourDurationS } = cfg;
   const noiseN = new AR1Noise(sigmaM);
   const noiseE = new AR1Noise(sigmaM);
   const noiseHeading = new AR1Noise(sigmaHeading);
@@ -542,6 +596,10 @@ function simulate(route, cfg) {
   let shortcutActive = false;
   let shortcutCompleted = false;
 
+  // Detour state
+  let detourActive = false;
+  let detourCompleted = false;
+
   for (let si = 0; si < segs.length; si++) {
     const seg = segs[si];
     const isOutage = cfg.outage && si >= outageStartSeg && si <= outageEndSeg;
@@ -596,6 +654,65 @@ function simulate(route, cfg) {
       groundTruth.push({ stop_idx: stopSeqIdx, lat: toLat, lon: toLon, timestamp: ts, phase: 'shortcut_end', event: 're_acquisition', off_route_duration_s: offRouteDuration });
     }
 
+    // Check for detour trigger
+    if (detour && !detourActive && !detourCompleted && seg.stopBefore && stopIndexMap[si] === detourFromStop) {
+      detourActive = true;
+      console.log(`Detour triggered at stop ${detourFromStop}, going via waypoint (${detourWaypointLat}, ${detourWaypointLon}) to stop ${detourToStop}`);
+
+      // Get coordinates from route points
+      const fromRoutePointIdx = stops[detourFromStop];
+      const toRoutePointIdx = stops[detourToStop];
+
+      const fromLat = route_points[fromRoutePointIdx][0];
+      const fromLon = route_points[fromRoutePointIdx][1];
+      const toLat = route_points[toRoutePointIdx][0];
+      const toLon = route_points[toRoutePointIdx][1];
+
+      // Calculate detour distances and bearings
+      const leg1Dist = haversine([fromLat, fromLon], [detourWaypointLat, detourWaypointLon]);
+      const leg1Bearing = bearing([fromLat, fromLon], [detourWaypointLat, detourWaypointLon]);
+      const leg2Dist = haversine([detourWaypointLat, detourWaypointLon], [toLat, toLon]);
+      const leg2Bearing = bearing([detourWaypointLat, detourWaypointLon], [toLat, toLon]);
+      const totalDetourDist = leg1Dist + leg2Dist;
+
+      console.log(`Detour leg1: ${leg1Dist.toFixed(0)}m, bearing ${leg1Bearing.toFixed(1)}°`);
+      console.log(`Detour leg2: ${leg2Dist.toFixed(0)}m, bearing ${leg2Bearing.toFixed(1)}°`);
+      console.log(`Total detour distance: ${totalDetourDist.toFixed(0)}m, target duration: ${detourDurationS}s`);
+
+      // Dwell at from_stop before detour
+      emitStatic([fromLat, fromLon], leg1Bearing, false);
+      groundTruth.push({ stop_idx: stopSeqIdx, lat: fromLat, lon: fromLon, timestamp: ts - STOP_DWELL_S, phase: 'detour_start', event: 'departure_detour' });
+
+      // Generate GPS points along detour leg 1 (from_stop -> waypoint)
+      const detourStartTS = ts;
+      const speedMs = totalDetourDist / detourDurationS; // Constant speed to match duration
+      let traveled = 0;
+
+      while (traveled < leg1Dist) {
+        const step = Math.min(speedMs, leg1Dist - traveled);
+        traveled += step;
+        const frac = traveled / leg1Dist;
+        const lat = fromLat + (detourWaypointLat - fromLat) * frac;
+        const lon = fromLon + (detourWaypointLon - fromLon) * frac;
+        emitGPS(lat, lon, speedMs, leg1Bearing, false);
+      }
+
+      // Leg 2 (waypoint -> to_stop)
+      traveled = 0;
+      while (traveled < leg2Dist) {
+        const step = Math.min(speedMs, leg2Dist - traveled);
+        traveled += step;
+        const frac = traveled / leg2Dist;
+        const lat = detourWaypointLat + (toLat - detourWaypointLat) * frac;
+        const lon = detourWaypointLon + (toLon - detourWaypointLon) * frac;
+        emitGPS(lat, lon, speedMs, leg2Bearing, false);
+      }
+
+      const offRouteDuration = ts - detourStartTS;
+      console.log(`Detour duration: ${offRouteDuration}s`);
+      groundTruth.push({ stop_idx: stopSeqIdx, lat: toLat, lon: toLon, timestamp: ts, phase: 'detour_end', event: 're_acquisition', off_route_duration_s: offRouteDuration });
+    }
+
     // Skip segments during shortcut (we've already injected GPS)
     if (shortcutActive) {
       if (seg.stopBefore && stopIndexMap[si] === shortcutToStop) {
@@ -605,6 +722,19 @@ function simulate(route, cfg) {
         // Continue processing this segment normally
       } else {
         // Skip this segment during shortcut
+        continue;
+      }
+    }
+
+    // Skip segments during detour (we've already injected GPS)
+    if (detourActive) {
+      if (seg.stopBefore && stopIndexMap[si] === detourToStop) {
+        detourActive = false;
+        detourCompleted = true;
+        console.log(`Detour completed at stop ${detourToStop}, resuming normal route`);
+        // Continue processing this segment normally
+      } else {
+        // Skip this segment during detour
         continue;
       }
     }
@@ -806,6 +936,15 @@ function cmdGenerate(args) {
   if (args.scenario === 'shortcut') {
     cfg.shortcutFromStop = args.shortcut_from_stop;
     cfg.shortcutToStop = args.shortcut_to_stop;
+  }
+
+  // Add custom detour parameters for detour scenario
+  if (args.scenario === 'detour') {
+    cfg.detourFromStop = args.detour_from_stop;
+    cfg.detourToStop = args.detour_to_stop;
+    cfg.detourWaypointLat = args.detour_waypoint_lat;
+    cfg.detourWaypointLon = args.detour_waypoint_lon;
+    cfg.detourDurationS = args.detour_duration_s;
   }
 
   // Load route file


### PR DESCRIPTION
## Summary

Fixes phantom arrivals during detours when the Kalman-filtered position (s_cm) drifts into "phantom territory" while the GPS is physically elsewhere.

## Problem

During detours:
1. Map matcher cannot project GPS onto nominal route → z_gps_cm gets arbitrary projection
2. Kalman filter dead-reckons along nominal route → s_cm drifts into phantom territory
3. During DrOutage: z_gps_cm = s_cm, so p1 and p3 collapse to same phantom signal
4. s_cm drifts into stop #2's corridor → p3 fires high → arrival declared spuriously

## Solution

**Divergence-Based Fallback:**
- When `z_gps_cm` and `s_cm` diverge by > 2000cm during Valid GPS:
  - Use `s_cm` for p1 (distance feature) instead of `z_gps_cm`
  - Keep p3 normal (not neutralized)
- During dr_outage/off_route with divergence > 5000cm:
  - Neutralize p3 to 128 (phantom arrival prevention)

**Key Insight:**
- Divergence > 2000cm indicates map matcher is producing poor projections
- Using s_cm for p1 prevents poor map matching from dragging down probability
- Threshold of 2000cm balances sensitivity vs. false positive prevention

## Changes

- `crates/shared/src/probability_constants.rs`: Add PHANTOM_DIVERGENCE_CM constant (5000cm)
- `crates/pipeline/detection/src/probability.rs`: Implement divergence-based fallback
- `crates/pico2-firmware/src/detection.rs`: Same divergence-based fallback logic
- `crates/pipeline/src/lib.rs`: Update probability calculation with GPS status mapping
- `tools/gen_nmea/gen_nmea.js`: Add "detour" scenario for testing
- `Makefile`: Add detour parameters and `make run-detour` target

## Test Results

**Detour Scenario:**
- Expected arrivals: stops 0, 1, 6, 7, 8, 9
- Actual arrivals: stops 0, 1, 6, 7, 8, 9
- Stops 2-5 correctly skipped during detour
- Detour duration: ~60s

**Integration Tests:**
- All 23 integration tests passing
- Normal tests: 5/5 passing (Recall: 100%, Precision: 100%)
- GPS anomaly tests: 5/5 passing
- Signal loss tests: 3/3 passing
- Edge case tests: 3/3 passing
- Route edge case tests: 5/5 passing
- Other tests: 2/2 passing

## Usage

```bash
# Run detour scenario
make run-detour

# Run detour on custom routes
make run ROUTE_NAME=xxx SCENARIO=detour DETOUR_FROM_STOP=1 DETOUR_TO_STOP=6
```

Fixes #4