### PR TITLE
feat: activate two-layer architecture (v9.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ crates/
 └── pico2-firmware/   # Embedded firmware (RP2350, no_std, embassy-rp)
 ```
 
-## Firmware Architecture (2-Layer Design)
+## Firmware Architecture (2-Layer Design) - ACTIVE
 
 The pico2-firmware crate implements a 2-layer architecture for embedded deployment:
 
@@ -100,6 +100,14 @@ The pico2-firmware crate implements a 2-layer architecture for embedded deployme
 - **Unified triggers:** All mode transitions use estimation signals only
 - **Single transition:** Only ONE mode change per tick (prevents race conditions)
 - **First-class recovery:** Recovery is a system mode, not inline logic
+
+## Migration Notes
+
+**v9.0 Architecture Migration (2026-04-29):**
+- Migrated from monolithic `state::State` to two-layer architecture
+- Old `state.rs` marked as deprecated
+- Bug fixes applied: C2 (Kalman predict), I1 (first fix), I3 (announcement guards)
+- See: `docs/superpowers/specs/2026-04-29-two-layer-activation-design.md`
 
 ## Testing
 

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -680,6 +680,50 @@ impl<'a> SystemState<'a> {
 
         best_idx
     }
+
+    /// Returns true if state should be persisted this tick.
+    /// Writes when stop index changes, but no more than once per 60 seconds.
+    /// This rate limiting prevents excessive flash wear (~100k erase cycles).
+    pub fn should_persist(&self, current_stop: u8) -> bool {
+        // M5: Gate persistence during off-route/suspect states
+        // Don't persist if position is frozen (off-route or suspect)
+        if self.frozen_s_cm.is_some() {
+            return false;
+        }
+
+        // Don't persist if in suspect state
+        if self.off_route_suspect_ticks > 0 {
+            return false;
+        }
+
+        // Only persist when stop index actually changes
+        if current_stop == self.last_persisted_stop {
+            return false;
+        }
+
+        // Rate limit: no more than once per 60 seconds (60 ticks at 1Hz)
+        if self.ticks_since_persist < 60 {
+            return false;
+        }
+
+        true
+    }
+
+    /// Mark state as persisted, resetting the rate-limit counter.
+    pub fn mark_persisted(&mut self, stop_index: u8) {
+        self.last_persisted_stop = stop_index;
+        self.ticks_since_persist = 0;
+    }
+
+    /// Get the current stop index from last_stop_index.
+    /// Returns None if not yet initialized.
+    pub fn current_stop_index(&self) -> Option<u8> {
+        if self.first_fix {
+            None
+        } else {
+            Some(self.last_stop_index)
+        }
+    }
 }
 
 /// Enforce hard monotonic invariant at system boundary.

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -391,23 +391,117 @@ impl<'a> SystemState<'a> {
 
     /// Run arrival detection (Normal mode only)
     fn run_detection(&mut self, est: &EstimationOutput, s_cm: DistCm, timestamp: u64) -> Option<ArrivalEvent> {
-        use crate::detection;
-        use shared::PositionSignals;
+        use crate::detection::{compute_arrival_probability_adaptive, find_active_stops};
+        use detection::state_machine::StopEvent;
 
         // Create position signals for detection
-        let signals = PositionSignals {
+        let signals = shared::PositionSignals {
             z_gps_cm: est.z_gps_cm,
             s_cm: est.s_cm,
         };
 
         // Find active stops (corridor filter)
-        let active_indices = detection::find_active_stops(signals, self.route_data);
+        let active_indices = find_active_stops(signals, self.route_data);
 
-        // TODO: Implement detection FSM when stop_states are integrated
-        // For now, return None to indicate no events
-        let _ = active_indices;
-        let _ = s_cm;
-        let _ = timestamp;
+        // Update state machine for each active stop
+        for stop_idx in active_indices {
+            if stop_idx >= self.stop_states.len() {
+                continue;
+            }
+
+            let stop = match self.route_data.get_stop(stop_idx) {
+                Some(s) => s,
+                None => continue,
+            };
+            let stop_state = &mut self.stop_states[stop_idx];
+
+            // Get next sequential stop for adaptive weights
+            let next_stop_idx = stop_idx.checked_add(1);
+            let next_stop_value = next_stop_idx.and_then(|idx| self.route_data.get_stop(idx));
+            let next_stop = next_stop_value.as_ref();
+
+            // Determine GPS status for probability computation
+            use crate::detection::GpsStatus;
+            let gps_status = GpsStatus::Valid;  // In Normal mode, GPS is valid
+
+            // Compute arrival probability with adaptive weights
+            let probability = compute_arrival_probability_adaptive(
+                signals,
+                est.v_cms,
+                &stop,
+                stop_state.dwell_time_s,
+                gps_status,
+                next_stop,
+            );
+
+            // Update state machine FIRST
+            let event = stop_state.update(
+                s_cm,
+                est.v_cms,
+                stop.progress_cm,
+                stop.corridor_start_cm,
+                probability,
+            );
+
+            // THEN check for announcement trigger
+            if stop_state.should_announce(s_cm, stop.corridor_start_cm) {
+                #[cfg(feature = "firmware")]
+                defmt::info!(
+                    "Announcement for stop {}: s={}cm, v={}cm/s",
+                    stop_idx,
+                    s_cm,
+                    est.v_cms
+                );
+                return Some(ArrivalEvent {
+                    time: timestamp,
+                    stop_idx: stop_idx as u8,
+                    s_cm,
+                    v_cms: est.v_cms,
+                    probability: 0,
+                    event_type: shared::ArrivalEventType::Announce,
+                });
+            }
+
+            // Check for arrival/departure events
+            match event {
+                StopEvent::Arrived => {
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Arrival at stop {}: s={}cm, v={}cm/s, p={}",
+                        stop_idx,
+                        s_cm,
+                        est.v_cms,
+                        probability
+                    );
+                    return Some(ArrivalEvent {
+                        time: timestamp,
+                        stop_idx: stop_idx as u8,
+                        s_cm,
+                        v_cms: est.v_cms,
+                        probability,
+                        event_type: shared::ArrivalEventType::Arrival,
+                    });
+                }
+                StopEvent::Departed => {
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Departure from stop {}: s={}cm, v={}cm/s",
+                        stop_idx,
+                        s_cm,
+                        est.v_cms
+                    );
+                    return Some(ArrivalEvent {
+                        time: timestamp,
+                        stop_idx: stop_idx as u8,
+                        s_cm,
+                        v_cms: est.v_cms,
+                        probability,
+                        event_type: shared::ArrivalEventType::Departure,
+                    });
+                }
+                StopEvent::None => {}
+            }
+        }
 
         None
     }

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -274,6 +274,12 @@ impl<'a> SystemState<'a> {
     /// - frozen_s_cm only accessed in OffRoute/Recovering modes
     /// - Only ONE transition executes per tick
     pub fn tick(&mut self, gps: &GpsPoint, est_state: &mut crate::estimation::EstimationState) -> Option<ArrivalEvent> {
+        // Handle snap cooldown decrement (must be before estimation)
+        if self.just_snapped_ticks > 0 {
+            self.just_snapped_ticks = self.just_snapped_ticks.saturating_sub(1);
+        }
+        let in_snap_cooldown = self.just_snapped_ticks > 0;
+
         // STEP 1: Isolated estimation
         let input = EstimationInput {
             gps: gps.clone(),
@@ -281,6 +287,28 @@ impl<'a> SystemState<'a> {
             is_first_fix: self.first_fix,
         };
         let est = crate::estimation::estimate(input, est_state);
+
+        // Handle snap from off-route re-entry
+        if est.snapped && !in_snap_cooldown {
+            // Find forward closest stop (prevents backward selection)
+            let new_idx = self.find_forward_closest_stop_index(est.s_cm, self.last_stop_index);
+            self.last_stop_index = new_idx;
+
+            // Reset stop states using recovery logic
+            self.reset_stop_states_after_recovery(new_idx as usize, est.s_cm);
+
+            // Clear all recovery triggers
+            self.frozen_s_cm = None;  // Clear freeze context
+            self.last_s_cm = est.s_cm;  // Update immediately to prevent false jump detection
+
+            // Set 2-second cooldown
+            self.just_snapped_ticks = 2;
+
+            #[cfg(feature = "firmware")]
+            defmt::info!("Snap re-entry at s={}cm, recovered stop={}", est.s_cm, new_idx);
+
+            // Continue to detection below
+        }
 
         // Handle GPS outage
         if !est.has_fix {

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -148,7 +148,49 @@ impl<'a> SystemState<'a> {
         self.recovery_failed = false;
         self.last_s_cm = s_cm;
 
-        // TODO: Reset stop states when detection layer is integrated
+        // Reset stop states after recovery
+        self.reset_stop_states_after_recovery(recovered_idx, s_cm);
+    }
+
+    /// Reset all stop states to Idle after recovery
+    fn reset_stop_states_after_recovery(&mut self, recovered_idx: usize, current_s_cm: DistCm) {
+        use shared::FsmState;
+
+        let recovered_was_announced = self
+            .stop_states
+            .get(recovered_idx)
+            .map(|state| state.announced || state.last_announced_stop == recovered_idx as u8)
+            .unwrap_or(false);
+
+        // Reset all stop states by recreating them
+        for i in 0..self.stop_states.len() {
+            self.stop_states[i] = detection::state_machine::StopState::new(i as u8);
+        }
+
+        // Stops before the recovered stop are treated as already passed.
+        // Preserve their announcement bookkeeping so recovery cannot re-announce them.
+        // I3 FIX: Set BOTH announced AND last_announced_stop
+        for i in 0..recovered_idx.min(self.stop_states.len()) {
+            self.stop_states[i].fsm_state = FsmState::Departed;
+            self.stop_states[i].announced = true;
+            self.stop_states[i].last_announced_stop = i as u8;  // I3: was missing
+        }
+
+        // Mark recovered stop as Approaching if within corridor
+        if let Some(stop) = self.route_data.get_stop(recovered_idx) {
+            if let Some(state) = self.stop_states.get_mut(recovered_idx) {
+                if recovered_was_announced {
+                    state.announced = true;
+                    state.last_announced_stop = recovered_idx as u8;
+                }
+
+                if current_s_cm >= stop.corridor_start_cm
+                    && current_s_cm <= stop.corridor_end_cm
+                {
+                    state.fsm_state = FsmState::Approaching;
+                }
+            }
+        }
     }
 
     /// Find closest stop index (for recovery timeout fallback)
@@ -193,7 +235,8 @@ impl<'a> SystemState<'a> {
             self.frozen_s_cm = None;
             self.recovering_since = None;
 
-            // TODO: Reset stop states when detection layer is integrated
+            // Reset stop states after recovery
+            self.reset_stop_states_after_recovery(best_idx as usize, est.s_cm);
 
             return Some(best_idx as usize);
         }

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -43,10 +43,34 @@ pub struct SystemState<'a> {
     pub last_s_cm: DistCm,
     /// Counter for backward jump events (GPS health monitoring)
     pub backward_jump_count: u32,
+    /// Per-stop FSM states for arrival detection
+    pub stop_states: heapless::Vec<detection::state_machine::StopState, 256>,
+    /// First fix flag - true until first GPS fix is received
+    pub first_fix: bool,
+    /// Warmup: valid GPS ticks where estimation ran
+    pub estimation_ready_ticks: u8,
+    /// Warmup: total ticks since first fix (timeout safety valve)
+    pub estimation_total_ticks: u8,
+    /// Detection gating: valid ticks since estimation ready
+    pub detection_enabled_ticks: u8,
+    /// Detection gating: total ticks for timeout
+    pub detection_total_ticks: u8,
+    /// Flag indicating state was just reset (e.g., after GPS outage)
+    pub just_reset: bool,
+    /// Ticks remaining in snap cooldown period (prevents recovery interference)
+    pub just_snapped_ticks: u8,
+    /// Last valid GPS timestamp for recovery dt calculation
+    pub last_gps_timestamp: u64,
 }
 
 impl<'a> SystemState<'a> {
     pub fn new(route_data: &'a RouteData<'a>, persisted: Option<shared::PersistedState>) -> Self {
+        // Initialize stop_states
+        let mut stop_states = heapless::Vec::new();
+        for i in 0..route_data.stop_count {
+            let _ = stop_states.push(detection::state_machine::StopState::new(i as u8));
+        }
+
         Self {
             mode: SystemMode::Normal,
             last_stop_index: 0,
@@ -62,6 +86,16 @@ impl<'a> SystemState<'a> {
             ticks_since_persist: 0,
             last_s_cm: 0,
             backward_jump_count: 0,
+            // NEW FIELDS
+            stop_states,
+            first_fix: true,
+            estimation_ready_ticks: 0,
+            estimation_total_ticks: 0,
+            detection_enabled_ticks: 0,
+            detection_total_ticks: 0,
+            just_reset: false,
+            just_snapped_ticks: 0,
+            last_gps_timestamp: 0,
         }
     }
 

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -278,15 +278,88 @@ impl<'a> SystemState<'a> {
         let input = EstimationInput {
             gps: gps.clone(),
             route_data: self.route_data,
-            is_first_fix: false,  // TODO: track first fix
+            is_first_fix: self.first_fix,
         };
         let est = crate::estimation::estimate(input, est_state);
 
         // Handle GPS outage
         if !est.has_fix {
-            // TODO: handle outage
+            // Reset warmup on GPS loss (conservative - requires fresh warmup after outage)
+            if !self.first_fix {
+                self.estimation_ready_ticks = 0;
+                self.estimation_total_ticks = 0;
+                self.detection_enabled_ticks = 0;
+                self.detection_total_ticks = 0;
+                self.just_reset = true;
+                #[cfg(feature = "firmware")]
+                defmt::debug!("GPS outage reset warmup counters");
+            }
             return None;
         }
+
+        // Handle first fix
+        if self.first_fix {
+            self.first_fix = false;
+            // First fix initializes Kalman but doesn't run update_adaptive
+            // Counts toward timeout but NOT convergence
+            self.estimation_total_ticks = 1;
+            self.detection_total_ticks = 1;
+            self.last_gps_timestamp = gps.timestamp;
+
+            // Apply persisted state if valid and within 500m threshold
+            if let Some(ps) = self.pending_persisted.take() {
+                let delta_cm = if est.s_cm >= ps.last_progress_cm {
+                    est.s_cm - ps.last_progress_cm
+                } else {
+                    ps.last_progress_cm - est.s_cm
+                };
+
+                if delta_cm <= 50_000 {
+                    // Within 500m: trust persisted stop index
+                    self.apply_persisted_stop_index(ps.last_stop_index);
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Applied persisted state: stop={}, delta={}cm",
+                        ps.last_stop_index,
+                        delta_cm
+                    );
+                } else {
+                    #[cfg(feature = "firmware")]
+                    defmt::warn!(
+                        "Persisted state too stale: delta={}cm > 500m, ignoring",
+                        delta_cm
+                    );
+                }
+            }
+
+            return None;
+        }
+
+        // Handle just_reset state
+        if self.just_reset {
+            // After warmup reset (e.g., GPS outage), first tick counts as first fix
+            self.just_reset = false;
+            self.estimation_total_ticks = 1;
+            self.detection_total_ticks = 1;
+            return None;
+        }
+
+        // Increment total time counters
+        self.estimation_total_ticks = self.estimation_total_ticks.saturating_add(1);
+        self.detection_total_ticks = self.detection_total_ticks.saturating_add(1);
+
+        // Update estimation readiness (until ready)
+        if !self.estimation_ready() {
+            self.estimation_ready_ticks += 1;
+        }
+
+        // Update detection readiness (until ready, independent of estimation)
+        if !self.detection_ready() {
+            self.detection_enabled_ticks += 1;
+        }
+
+        // Update last GPS timestamp for recovery dt calculation
+        self.last_gps_timestamp = gps.timestamp;
 
         // STEP 1.5: Enforce monotonic invariant
         // CRITICAL: Use current_position() to get mode-specific position
@@ -383,7 +456,10 @@ impl<'a> SystemState<'a> {
 
         // STEP 4: Detection (ONLY in Normal mode)
         if self.mode == SystemMode::Normal {
-            return self.run_detection(&est, s_cm_for_detection, gps.timestamp);
+            // Block detection unless ready
+            if self.detection_ready() {
+                return self.run_detection(&est, s_cm_for_detection, gps.timestamp);
+            }
         }
 
         None
@@ -537,6 +613,21 @@ impl<'a> SystemState<'a> {
         }
 
         closest_idx as u8
+    }
+
+    /// Apply persisted stop index by marking all prior stops as Departed.
+    ///
+    /// This prevents the corridor filter from re-triggering stops that
+    /// were already passed before the reboot.
+    fn apply_persisted_stop_index(&mut self, stop_index: u8) {
+        use shared::FsmState;
+
+        for i in 0..stop_index.min(self.stop_states.len() as u8) as usize {
+            self.stop_states[i].fsm_state = FsmState::Departed;
+            self.stop_states[i].announced = true;
+            self.stop_states[i].last_announced_stop = i as u8;  // I3 fix
+        }
+        self.last_stop_index = stop_index;
     }
 
     /// Find closest stop index in forward direction only

--- a/crates/pico2-firmware/src/control/mod.rs
+++ b/crates/pico2-firmware/src/control/mod.rs
@@ -368,6 +368,62 @@ impl<'a> SystemState<'a> {
 
         None
     }
+
+    /// Check if estimation is ready (affects heading filter, Kalman)
+    pub fn estimation_ready(&self) -> bool {
+        self.estimation_ready_ticks >= 3 || self.estimation_total_ticks >= 10
+    }
+
+    /// Check if detection is enabled (independent of estimation)
+    pub fn detection_ready(&self) -> bool {
+        self.detection_enabled_ticks >= 3 || self.detection_total_ticks >= 10
+    }
+
+    /// Check if heading filter should be disabled
+    pub fn disable_heading_filter(&self) -> bool {
+        self.first_fix || !self.estimation_ready()
+    }
+
+    /// Find closest stop index to current position
+    pub fn find_closest_stop_index(&self, s_cm: DistCm) -> u8 {
+        let mut closest_idx = 0;
+        let mut closest_dist = i32::MAX;
+
+        for i in 0..self.route_data.stop_count {
+            if let Some(stop) = self.route_data.get_stop(i) {
+                let dist = (s_cm - stop.progress_cm).abs();
+                if dist < closest_dist {
+                    closest_dist = dist;
+                    closest_idx = i;
+                }
+            }
+        }
+
+        closest_idx as u8
+    }
+
+    /// Find closest stop index in forward direction only
+    ///
+    /// Searches from last_idx to end of route only. This prevents
+    /// selecting stops behind the current position, which is important
+    /// after off-route snap re-entry.
+    pub fn find_forward_closest_stop_index(&self, s_cm: DistCm, last_idx: u8) -> u8 {
+        let mut best_idx = last_idx;
+        let mut best_dist = i32::MAX;
+
+        // Only search forward: from last_idx to end of route
+        for i in last_idx as usize..self.route_data.stop_count {
+            if let Some(stop) = self.route_data.get_stop(i) {
+                let dist = (s_cm - stop.progress_cm).abs();
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_idx = i as u8;
+                }
+            }
+        }
+
+        best_idx
+    }
 }
 
 /// Enforce hard monotonic invariant at system boundary.

--- a/crates/pico2-firmware/src/estimation/kalman.rs
+++ b/crates/pico2-firmware/src/estimation/kalman.rs
@@ -33,8 +33,14 @@ impl KalmanState {
             13
         };
 
-        // Position update
-        self.s_cm = self.s_cm + k_pos * (z_raw - self.s_cm) / 256;
+        // Predict step: propagate velocity into position
+        let s_pred = self.s_cm + self.v_cms;
+
+        // Innovation term uses predicted position
+        let innovation = z_raw - s_pred;
+
+        // Update step with innovation
+        self.s_cm = s_pred + k_pos * innovation / 256;
 
         // Velocity update (fixed gain)
         self.v_cms = self.v_cms + 77 * (v_gps - self.v_cms) / 256;

--- a/crates/pico2-firmware/src/estimation/mod.rs
+++ b/crates/pico2-firmware/src/estimation/mod.rs
@@ -16,6 +16,7 @@ pub use dr::DrState;
 pub struct EstimationState {
     pub kalman: KalmanState,
     pub dr: DrState,
+    first_fix_called: bool,  // track if estimate() has ever been called with valid fix
 }
 
 impl EstimationState {
@@ -23,6 +24,7 @@ impl EstimationState {
         Self {
             kalman: KalmanState::new(),
             dr: DrState::new(),
+            first_fix_called: false,
         }
     }
 }
@@ -69,6 +71,12 @@ pub fn estimate(
 ) -> EstimationOutput {
     use gps_processor::map_match;
 
+    // Track first fix
+    let is_first_fix = !state.first_fix_called && input.gps.has_fix;
+    if input.gps.has_fix {
+        state.first_fix_called = true;
+    }
+
     // Check for GPS outage
     if !input.gps.has_fix {
         return handle_outage(state, input.gps.timestamp);
@@ -82,7 +90,7 @@ pub fn estimate(
     );
 
     // 2. Map matching
-    let use_relaxed_heading = input.is_first_fix || state.dr.in_recovery;
+    let use_relaxed_heading = is_first_fix || state.dr.in_recovery;
     let (seg_idx, match_d2) = map_match::find_best_segment_restricted(
         gps_x,
         gps_y,
@@ -108,7 +116,7 @@ pub fn estimate(
     }
 
     // 4. Kalman filter
-    let (s_cm, v_cms) = if input.is_first_fix {
+    let (s_cm, v_cms) = if is_first_fix {
         // First fix: initialize Kalman
         state.kalman.s_cm = z_raw;
         let v_gps = input.gps.speed_cms.max(0).min(1667);

--- a/crates/pico2-firmware/src/estimation/mod.rs
+++ b/crates/pico2-firmware/src/estimation/mod.rs
@@ -48,6 +48,8 @@ pub struct EstimationOutput {
     pub confidence: u8,
     /// Whether GPS has valid fix
     pub has_fix: bool,
+    /// True if map-matching snapped from off-route back to route
+    pub snapped: bool,
 }
 
 /// Isolated estimation pipeline
@@ -96,6 +98,15 @@ pub fn estimate(
         gps_x, gps_y, seg_idx, input.route_data
     );
 
+    // Detect snap: was previously off-route (high divergence) but now on-route
+    let was_off_route = state.dr.in_recovery;
+    let snapped = was_off_route && match_d2 < 25_000_000;  // 50m threshold
+
+    // Clear recovery flag when snap is detected
+    if snapped {
+        state.dr.in_recovery = false;
+    }
+
     // 4. Kalman filter
     let (s_cm, v_cms) = if input.is_first_fix {
         // First fix: initialize Kalman
@@ -136,6 +147,7 @@ pub fn estimate(
         divergence_d2: match_d2,
         confidence,
         has_fix: true,
+        snapped,
     }
 }
 
@@ -152,6 +164,7 @@ fn handle_outage(state: &mut EstimationState, timestamp: u64) -> EstimationOutpu
             divergence_d2: 0,
             confidence: 0,
             has_fix: false,
+            snapped: false,
         },
     };
 
@@ -164,6 +177,7 @@ fn handle_outage(state: &mut EstimationState, timestamp: u64) -> EstimationOutpu
             divergence_d2: 0,
             confidence: 0,
             has_fix: false,
+            snapped: false,
         };
     }
 
@@ -183,6 +197,7 @@ fn handle_outage(state: &mut EstimationState, timestamp: u64) -> EstimationOutpu
         divergence_d2: 0,
         confidence: 0,
         has_fix: false,
+        snapped: false,
     }
 }
 

--- a/crates/pico2-firmware/src/main.rs
+++ b/crates/pico2-firmware/src/main.rs
@@ -18,12 +18,18 @@ use embassy_rp::flash::Flash;
 use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, Config as UartConfig};
 
 // Module declarations
+mod control;
 mod detection;
+mod estimation;
 mod lut;
 mod persist;
 mod recovery_trigger;
-mod state;
+mod state;  // Deprecated: kept for reference
 mod uart;
+
+use crate::control::SystemState;
+use crate::estimation::EstimationState;
+use gps_processor::nmea::NmeaState;
 
 // Note: embassy-rp doesn't require external bootloader
 // The RP2350 has built-in boot ROM
@@ -97,8 +103,12 @@ async fn main(_spawner: Spawner) {
         info!("No valid persisted state, cold start");
     }
 
-    // Initialize state with route data reference
-    let mut state = state::State::new(&route_data, persisted);
+    // Initialize system state with route data reference
+    let mut system_state = SystemState::new(&route_data, persisted);
+    let mut estimation_state = EstimationState::new();
+
+    // Initialize NMEA parser (standalone, separate from system state)
+    let mut nmea = NmeaState::new();
 
     // Initialize line buffer for NMEA data
     let mut line_buf = uart::UartLineBuffer::new();
@@ -115,11 +125,11 @@ async fn main(_spawner: Spawner) {
                     debug!("NMEA: {}", sentence);
 
                     // Parse NMEA sentence
-                    if let Some(gps) = state.nmea.parse_sentence(sentence) {
+                    if let Some(gps) = nmea.parse_sentence(sentence) {
                         debug!("GPS: lat={}, lon={}, fix={}", gps.lat, gps.lon, gps.has_fix);
 
                         // Process GPS through full pipeline
-                        if let Some(arrival) = state.process_gps(&gps) {
+                        if let Some(arrival) = system_state.tick(&gps, &mut estimation_state) {
                             // Emit arrival event via UART
                             match uart::write_arrival_event_async(&mut uart, &arrival).await {
                                 Ok(()) => {
@@ -152,26 +162,29 @@ async fn main(_spawner: Spawner) {
         }
 
         // Persist state if stop index changed and rate limit allows
-        if let Some(current_stop) = state.current_stop_index() {
-            if state.should_persist(current_stop) {
-                let ps = shared::PersistedState::new(state.kalman.s_cm, current_stop);
+        if let Some(current_stop) = system_state.current_stop_index() {
+            if system_state.should_persist(current_stop) {
+                let ps = shared::PersistedState::new(
+                    estimation_state.kalman.s_cm,
+                    current_stop
+                );
                 match persist::save(&mut flash, &ps).await {
                     Ok(()) => {
                         info!(
                             "Persisted state: stop={}, progress={}cm",
-                            current_stop, state.kalman.s_cm
+                            current_stop, estimation_state.kalman.s_cm
                         );
-                        state.mark_persisted(current_stop);
+                        system_state.mark_persisted(current_stop);
                     }
                     Err(()) => {
                         defmt::warn!("Failed to persist state to flash");
                         // S4 fix: increment on failure to prevent retry loop
-                        state.ticks_since_persist = state.ticks_since_persist.saturating_add(1);
+                        system_state.ticks_since_persist = system_state.ticks_since_persist.saturating_add(1);
                     }
                 }
             } else {
                 // Increment tick counter for rate limiting
-                state.ticks_since_persist = state.ticks_since_persist.saturating_add(1);
+                system_state.ticks_since_persist = system_state.ticks_since_persist.saturating_add(1);
             }
         }
 

--- a/crates/pico2-firmware/src/state.rs
+++ b/crates/pico2-firmware/src/state.rs
@@ -2,6 +2,7 @@
 //!
 //! Manages the main state machine for processing GPS updates through
 //! the full arrival detection pipeline.
+#![deprecated(note = "Use control::SystemState + estimation::EstimationState instead")]
 #![allow(dead_code)]
 
 use crate::detection::{compute_arrival_probability_adaptive, find_active_stops};
@@ -72,6 +73,7 @@ const WARMUP_TIMEOUT_TICKS: u8 = 10;
 ///
 /// Dead-reckoning outages ([`ProcessResult::DrOutage`]) do NOT reset counters
 /// because DR mode maintains valid state estimates.
+#[deprecated(note = "Use control::SystemState instead")]
 pub struct State<'a> {
     pub nmea: gps_processor::nmea::NmeaState,
     pub kalman: KalmanState,

--- a/crates/pico2-firmware/tests/test_monotonic_invariant.rs
+++ b/crates/pico2-firmware/tests/test_monotonic_invariant.rs
@@ -5,11 +5,15 @@
 
 use pico2_firmware::control::SystemState;
 use pico2_firmware::estimation::EstimationState;
-use shared::{binfile::RouteData, EARTH_R_CM, FIXED_ORIGIN_LAT_DEG, FIXED_ORIGIN_LON_DEG, GpsPoint, RouteNode};
+use shared::{EARTH_R_CM, FIXED_ORIGIN_LAT_DEG, FIXED_ORIGIN_LON_DEG, GpsPoint};
+
+#[cfg(feature = "dev")]
+use shared::{RouteNode, binfile::RouteData};
 
 const FIXED_ORIGIN_LAT_RAD: f64 = FIXED_ORIGIN_LAT_DEG.to_radians();
 
 /// Helper: Create a simple test route
+#[cfg(feature = "dev")]
 fn create_test_route_data() -> RouteData<'static> {
     use shared::SpatialGrid;
 
@@ -174,18 +178,28 @@ fn test_first_fix_initialization() {
     let mut state = SystemState::new(&route_data, None);
     let mut est_state = EstimationState::new();
 
-    // Initially, last_s_cm should be 0
+    // Initially, last_s_cm should be 0 and first_fix should be true
     assert_eq!(state.last_s_cm, 0, "last_s_cm starts at 0");
+    assert!(state.first_fix, "first_fix should be true initially");
 
-    // First GPS fix should initialize without clamping
-    let gps = gps_on_route_at_x(1000, 10000, 500);
-    state.tick(&gps, &mut est_state);
+    // First GPS fix: clears first_fix flag but doesn't update last_s_cm yet
+    // (returns early to allow Kalman initialization)
+    let gps1 = gps_on_route_at_x(1000, 10000, 500);
+    let event1 = state.tick(&gps1, &mut est_state);
 
-    // After first fix, last_s_cm should be set
-    assert_ne!(state.last_s_cm, 0, "last_s_cm should be initialized");
+    assert!(event1.is_none(), "No event on first fix");
+    assert!(!state.first_fix, "first_fix should be cleared");
+    assert_eq!(state.last_s_cm, 0, "last_s_cm still 0 after first tick (updated on second tick)");
+
+    // Second GPS fix: now last_s_cm is updated
+    let gps2 = gps_on_route_at_x(1001, 10500, 500);
+    let event2 = state.tick(&gps2, &mut est_state);
+
+    assert!(event2.is_none(), "No event on second tick (still in warmup)");
+    assert_ne!(state.last_s_cm, 0, "last_s_cm should be initialized after second tick");
     assert_eq!(
         state.backward_jump_count, 0,
-        "No backward jumps on first fix"
+        "No backward jumps during initialization"
     );
 }
 
@@ -243,7 +257,7 @@ fn test_recovering_mode_allows_backward() {
         state.tick(&gps, &mut est_state);
     }
 
-    let position_at_offroute_entry = state.last_s_cm;
+    let _position_at_offroute_entry = state.last_s_cm;
 
     // Trigger OffRoute (GPS far from route) - multiple ticks needed
     // Use a point far north to cause large divergence

--- a/docs/superpowers/plans/2026-04-29-two-layer-activation.md
+++ b/docs/superpowers/plans/2026-04-29-two-layer-activation.md
@@ -1,0 +1,1303 @@
+# Two-Layer Architecture Activation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate the v9.0 two-layer architecture (control::SystemState + estimation::estimate) in main.rs while preserving all functionality and fixing known bugs (C2, I1, I3, snap signal).
+
+**Architecture:** Migrate from monolithic `state::State::process_gps()` to layered design where `estimate()` (pure function) produces position signals, `SystemState::tick()` orchestrates mode transitions and detection, and detection FSM emits arrival events.
+
+**Tech Stack:** Rust no_std embedded firmware, RP2350 target, embassy-rp async framework
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `crates/pico2-firmware/src/estimation/mod.rs` - Add snapped signal, first_fix tracking
+- `crates/pico2-firmware/src/estimation/kalman.rs` or `gps_processor/src/kalman.rs` - Add predict step (C2 fix)
+- `crates/pico2-firmware/src/control/mod.rs` - Complete detection integration, add missing state
+- `crates/pico2-firmware/src/main.rs` - Switch to new architecture
+- `crates/pico2-firmware/src/state.rs` - Mark deprecated
+
+**Files to reference (read-only):**
+- `crates/pico2-firmware/src/detection.rs` - Detection functions (already exist)
+- `crates/pico2-firmware/src/recovery/mod.rs` - Recovery module (already exists)
+
+---
+
+## Task 1: Add Kalman Predict Step (C2 Fix)
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/estimation/kalman.rs` or `gps_processor/src/kalman.rs` (whichever contains `update_adaptive()`)
+
+**Reference:** Old `state.rs:175-184` shows the predict step happens before Kalman update
+
+- [ ] **Step 1: Locate update_adaptive method**
+
+Find the `update_adaptive()` method in the Kalman implementation. Look for the line that updates `self.s_cm` directly with the innovation term:
+```rust
+self.s_cm = self.s_cm + k_pos * (z_raw - self.s_cm) / 256;
+```
+
+- [ ] **Step 2: Add predict step before update**
+
+Add the predict step that propagates velocity into position BEFORE the innovation calculation:
+```rust
+// Predict step: propagate velocity into position
+let s_pred = self.s_cm + self.v_cms;
+
+// Innovation term uses predicted position
+let innovation = z_raw - s_pred;
+
+// Update step with innovation
+self.s_cm = s_pred + k_pos * innovation / 256;
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/pico2-firmware/src/estimation/kalman.rs
+git commit -m "fix(estimation): add Kalman predict step before update (C2)
+
+Without predict step, velocity is never propagated into position prediction,
+causing systematic lag proportional to bus speed (~16 cm/tick at 30 km/h).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add Snapped Signal to EstimationOutput
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/estimation/mod.rs`
+
+**Reference:** Old `ProcessResult::Valid { snapped, .. }` in `gps_processor`
+
+- [ ] **Step 1: Add snapped field to EstimationOutput struct**
+
+```rust
+pub struct EstimationOutput {
+    pub z_gps_cm: DistCm,
+    pub s_cm: DistCm,
+    pub v_cms: SpeedCms,
+    pub divergence_d2: Dist2,
+    pub confidence: u8,
+    pub has_fix: bool,
+    pub snapped: bool,  // ADD THIS: true if map-matching snapped from off-route
+}
+```
+
+- [ ] **Step 2: Initialize snapped in all return paths**
+
+Find all `return EstimationOutput { ... }` statements and add `snapped: false,` to each. In `estimate()` function, after map matching:
+
+```rust
+// Detect snap: was previously off-route (high divergence) but now on-route
+let was_off_route = state.dr.in_recovery;
+let snapped = was_off_route && match_d2 < 25_000_000;  // 50m threshold
+
+// In all EstimationOutput returns, include snapped field
+EstimationOutput {
+    // ... existing fields ...
+    snapped,
+}
+```
+
+- [ ] **Step 3: Set in_recovery appropriately**
+
+Ensure `state.dr.in_recovery` is set to `false` when snap is detected:
+```rust
+if snapped {
+    state.dr.in_recovery = false;
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/pico2-firmware/src/estimation/mod.rs
+git commit -m "feat(estimation): add snapped signal to EstimationOutput
+
+Indicates when map-matching snaps from off-route back to route.
+Required for snap cooldown logic in control layer.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add First Fix Tracking to EstimationState
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/estimation/mod.rs`
+
+**Reference:** Old `state.rs:82, 255-292` shows first_fix handling
+
+- [ ] **Step 1: Add first_fix_called field to EstimationState**
+
+```rust
+pub struct EstimationState {
+    pub kalman: KalmanState,
+    pub dr: DrState,
+    first_fix_called: bool,  // ADD THIS: track if estimate() has ever been called with valid fix
+}
+```
+
+- [ ] **Step 2: Initialize in new() method**
+
+```rust
+impl EstimationState {
+    pub fn new() -> Self {
+        Self {
+            kalman: KalmanState::new(),
+            dr: DrState::new(),
+            first_fix_called: false,
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Track first fix in estimate() function**
+
+At the start of `estimate()`, check and update first_fix_called:
+```rust
+pub fn estimate(
+    input: EstimationInput,
+    state: &mut EstimationState,
+) -> EstimationOutput {
+    // Track first fix
+    let is_first_fix = !state.first_fix_called && input.gps.has_fix;
+    if input.gps.has_fix {
+        state.first_fix_called = true;
+    }
+
+    // ... rest of estimate() function
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/pico2-firmware/src/estimation/mod.rs
+git commit -m "feat(estimation): track first fix state (I1 fix)
+
+Removes hardcoded is_first_fix: false in control layer.
+Enables proper cold-start Kalman initialization.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add Missing Fields to SystemState
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:75-115` shows all required fields
+
+- [ ] **Step 1: Add stop_states field**
+
+After line 42, add:
+```rust
+/// Per-stop FSM states for arrival detection
+pub stop_states: heapless::Vec<detection::state_machine::StopState, 256>,
+```
+
+- [ ] **Step 2: Add warmup counters**
+
+After the new stop_states field, add:
+```rust
+/// First fix flag - true until first GPS fix is received
+pub first_fix: bool,
+
+/// Warmup: valid GPS ticks where estimation ran
+pub estimation_ready_ticks: u8,
+
+/// Warmup: total ticks since first fix (timeout safety valve)
+pub estimation_total_ticks: u8,
+
+/// Detection gating: valid ticks since estimation ready
+pub detection_enabled_ticks: u8,
+
+/// Detection gating: total ticks for timeout
+pub detection_total_ticks: u8,
+```
+
+- [ ] **Step 3: Add reset and cooldown flags**
+
+Continue adding:
+```rust
+/// Flag indicating state was just reset (e.g., after GPS outage)
+pub just_reset: bool,
+
+/// Ticks remaining in snap cooldown period (prevents recovery interference)
+pub just_snapped_ticks: u8,
+
+/// Last valid GPS timestamp for recovery dt calculation
+pub last_gps_timestamp: u64,
+```
+
+- [ ] **Step 4: Initialize all fields in new() method**
+
+Update `SystemState::new()` to initialize the new fields:
+```rust
+pub fn new(route_data: &'a RouteData<'a>, persisted: Option<shared::PersistedState>) -> Self {
+    // Initialize stop_states
+    let mut stop_states = heapless::Vec::new();
+    for i in 0..route_data.stop_count {
+        let _ = stop_states.push(detection::state_machine::StopState::new(i as u8));
+    }
+
+    Self {
+        mode: SystemMode::Normal,
+        last_stop_index: 0,
+        frozen_s_cm: None,
+        off_route_clear_ticks: 0,
+        off_route_suspect_ticks: 0,
+        off_route_since: None,
+        recovering_since: None,
+        recovery_failed: false,
+        route_data,
+        pending_persisted: persisted,
+        last_persisted_stop: persisted.map(|p| p.last_stop_index).unwrap_or(0),
+        ticks_since_persist: 0,
+        last_s_cm: 0,
+        backward_jump_count: 0,
+        // NEW FIELDS
+        stop_states,
+        first_fix: true,
+        estimation_ready_ticks: 0,
+        estimation_total_ticks: 0,
+        detection_enabled_ticks: 0,
+        detection_total_ticks: 0,
+        just_reset: false,
+        just_snapped_ticks: 0,
+        last_gps_timestamp: 0,
+    }
+}
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add missing state fields to SystemState
+
+Adds stop_states, warmup counters, reset flags, and snap cooldown.
+Required for detection integration and parity with old state.rs.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Implement Helper Methods
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:587-768` for helper method implementations
+
+- [ ] **Step 1: Add estimation_ready() method**
+
+```rust
+impl<'a> SystemState<'a> {
+    /// Check if estimation is ready (affects heading filter, Kalman)
+    pub fn estimation_ready(&self) -> bool {
+        self.estimation_ready_ticks >= 3 || self.estimation_total_ticks >= 10
+    }
+}
+```
+
+- [ ] **Step 2: Add detection_ready() method**
+
+```rust
+    /// Check if detection is enabled (independent of estimation)
+    pub fn detection_ready(&self) -> bool {
+        self.detection_enabled_ticks >= 3 || self.detection_total_ticks >= 10
+    }
+```
+
+- [ ] **Step 3: Add disable_heading_filter() method**
+
+```rust
+    /// Check if heading filter should be disabled
+    pub fn disable_heading_filter(&self) -> bool {
+        self.first_fix || !self.estimation_ready()
+    }
+```
+
+- [ ] **Step 4: Add find_closest_stop_index() method**
+
+```rust
+    /// Find closest stop index to current position
+    pub fn find_closest_stop_index(&self, s_cm: DistCm) -> u8 {
+        let mut closest_idx = 0;
+        let mut closest_dist = i32::MAX;
+
+        for i in 0..self.route_data.stop_count {
+            if let Some(stop) = self.route_data.get_stop(i) {
+                let dist = (s_cm - stop.progress_cm).abs();
+                if dist < closest_dist {
+                    closest_dist = dist;
+                    closest_idx = i;
+                }
+            }
+        }
+
+        closest_idx as u8
+    }
+```
+
+- [ ] **Step 5: Add find_forward_closest_stop_index() method**
+
+```rust
+    /// Find closest stop index in forward direction only
+    ///
+    /// Searches from last_idx to end of route only. This prevents
+    /// selecting stops behind the current position, which is important
+    /// after off-route snap re-entry.
+    pub fn find_forward_closest_stop_index(&self, s_cm: DistCm, last_idx: u8) -> u8 {
+        let mut best_idx = last_idx;
+        let mut best_dist = i32::MAX;
+
+        // Only search forward: from last_idx to end of route
+        for i in last_idx as usize..self.route_data.stop_count {
+            if let Some(stop) = self.route_data.get_stop(i) {
+                let dist = (s_cm - stop.progress_cm).abs();
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_idx = i as u8;
+                }
+            }
+        }
+
+        best_idx
+    }
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add helper methods to SystemState
+
+Adds estimation_ready(), detection_ready(), disable_heading_filter(),
+find_closest_stop_index(), and find_forward_closest_stop_index().
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Implement Stop State Reset Logic
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:635-673` for exact logic, including I3 fix
+
+- [ ] **Step 1: Add reset_stop_states_after_recovery() method**
+
+```rust
+impl<'a> SystemState<'a> {
+    /// Reset all stop states to Idle after recovery
+    fn reset_stop_states_after_recovery(&mut self, recovered_idx: usize, current_s_cm: DistCm) {
+        use shared::FsmState;
+
+        let recovered_was_announced = self
+            .stop_states
+            .get(recovered_idx)
+            .map(|state| state.announced || state.last_announced_stop == recovered_idx as u8)
+            .unwrap_or(false);
+
+        // Reset all stop states by recreating them
+        for i in 0..self.stop_states.len() {
+            self.stop_states[i] = detection::state_machine::StopState::new(i as u8);
+        }
+
+        // Stops before the recovered stop are treated as already passed.
+        // Preserve their announcement bookkeeping so recovery cannot re-announce them.
+        // I3 FIX: Set BOTH announced AND last_announced_stop
+        for i in 0..recovered_idx.min(self.stop_states.len()) {
+            self.stop_states[i].fsm_state = FsmState::Departed;
+            self.stop_states[i].announced = true;
+            self.stop_states[i].last_announced_stop = i as u8;  // I3: was missing
+        }
+
+        // Mark recovered stop as Approaching if within corridor
+        if let Some(stop) = self.route_data.get_stop(recovered_idx) {
+            if let Some(state) = self.stop_states.get_mut(recovered_idx) {
+                if recovered_was_announced {
+                    state.announced = true;
+                    state.last_announced_stop = recovered_idx as u8;
+                }
+
+                if current_s_cm >= stop.corridor_start_cm
+                    && current_s_cm <= stop.corridor_end_cm
+                {
+                    state.fsm_state = FsmState::Approaching;
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add stop state reset logic with I3 fix
+
+Implements reset_stop_states_after_recovery() with proper announcement
+guard handling. Sets both announced and last_announced_stop to prevent
+re-announcement of passed stops (I3 fix).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Implement run_detection() Method
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:487-584` for complete detection flow
+
+- [ ] **Step 1: Replace run_detection() stub with full implementation**
+
+Replace the entire `run_detection()` method (lines 315-336) with:
+
+```rust
+    /// Run arrival detection (Normal mode only)
+    fn run_detection(&mut self, est: &EstimationOutput, s_cm: DistCm, timestamp: u64) -> Option<ArrivalEvent> {
+        use crate::detection::{compute_arrival_probability_adaptive, find_active_stops};
+        use detection::state_machine::StopEvent;
+
+        // Create position signals for detection
+        let signals = shared::PositionSignals {
+            z_gps_cm: est.z_gps_cm,
+            s_cm: est.s_cm,
+        };
+
+        // Find active stops (corridor filter)
+        let active_indices = find_active_stops(signals, self.route_data);
+
+        // Update state machine for each active stop
+        for stop_idx in active_indices {
+            if stop_idx >= self.stop_states.len() {
+                continue;
+            }
+
+            let stop = match self.route_data.get_stop(stop_idx) {
+                Some(s) => s,
+                None => continue,
+            };
+            let stop_state = &mut self.stop_states[stop_idx];
+
+            // Get next sequential stop for adaptive weights
+            let next_stop_idx = stop_idx.checked_add(1);
+            let next_stop_value = next_stop_idx.and_then(|idx| self.route_data.get_stop(idx));
+            let next_stop = next_stop_value.as_ref();
+
+            // Determine GPS status for probability computation
+            use crate::detection::GpsStatus;
+            let gps_status = GpsStatus::Valid;  // In Normal mode, GPS is valid
+
+            // Compute arrival probability with adaptive weights
+            let probability = compute_arrival_probability_adaptive(
+                signals,
+                est.v_cms,
+                &stop,
+                stop_state.dwell_time_s,
+                gps_status,
+                next_stop,
+            );
+
+            // Update state machine FIRST
+            let event = stop_state.update(
+                s_cm,
+                est.v_cms,
+                stop.progress_cm,
+                stop.corridor_start_cm,
+                probability,
+            );
+
+            // THEN check for announcement trigger
+            if stop_state.should_announce(s_cm, stop.corridor_start_cm) {
+                #[cfg(feature = "firmware")]
+                defmt::info!(
+                    "Announcement for stop {}: s={}cm, v={}cm/s",
+                    stop_idx,
+                    s_cm,
+                    est.v_cms
+                );
+                return Some(ArrivalEvent {
+                    time: timestamp,
+                    stop_idx: stop_idx as u8,
+                    s_cm,
+                    v_cms: est.v_cms,
+                    probability: 0,
+                    event_type: shared::ArrivalEventType::Announce,
+                });
+            }
+
+            // Check for arrival/departure events
+            match event {
+                StopEvent::Arrived => {
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Arrival at stop {}: s={}cm, v={}cm/s, p={}",
+                        stop_idx,
+                        s_cm,
+                        est.v_cms,
+                        probability
+                    );
+                    return Some(ArrivalEvent {
+                        time: timestamp,
+                        stop_idx: stop_idx as u8,
+                        s_cm,
+                        v_cms: est.v_cms,
+                        probability,
+                        event_type: shared::ArrivalEventType::Arrival,
+                    });
+                }
+                StopEvent::Departed => {
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Departure from stop {}: s={}cm, v={}cm/s",
+                        stop_idx,
+                        s_cm,
+                        est.v_cms
+                    );
+                    return Some(ArrivalEvent {
+                        time: timestamp,
+                        stop_idx: stop_idx as u8,
+                        s_cm,
+                        v_cms: est.v_cms,
+                        probability,
+                        event_type: shared::ArrivalEventType::Departure,
+                    });
+                }
+                StopEvent::None => {}
+            }
+        }
+
+        None
+    }
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): implement full arrival detection in run_detection()
+
+Replaces TODO stub with complete detection pipeline:
+- Corridor filtering via find_active_stops()
+- Adaptive probability computation
+- StopState FSM transitions
+- Arrival/Departure/Announce event emission
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Update tick() Method with Warmup and First Fix Logic
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:164-320` for warmup and first fix handling
+
+- [ ] **Step 1: Remove hardcoded is_first_fix**
+
+Replace line 204 `is_first_fix: false,  // TODO: track first fix` with:
+```rust
+is_first_fix: self.first_fix,
+```
+
+- [ ] **Step 2: Add GPS outage handling before mode transitions**
+
+After line 212 (after `let est = ...`), add:
+```rust
+        // Handle GPS outage
+        if !est.has_fix {
+            // Reset warmup on GPS loss (conservative - requires fresh warmup after outage)
+            if !self.first_fix {
+                self.estimation_ready_ticks = 0;
+                self.estimation_total_ticks = 0;
+                self.detection_enabled_ticks = 0;
+                self.detection_total_ticks = 0;
+                self.just_reset = true;
+                #[cfg(feature = "firmware")]
+                defmt::debug!("GPS outage reset warmup counters");
+            }
+            return None;
+        }
+```
+
+- [ ] **Step 3: Add warmup counter logic after outage check**
+
+Continue adding:
+```rust
+        // Handle first fix
+        if self.first_fix {
+            self.first_fix = false;
+            // First fix initializes Kalman but doesn't run update_adaptive
+            // Counts toward timeout but NOT convergence
+            self.estimation_total_ticks = 1;
+            self.detection_total_ticks = 1;
+            self.last_gps_timestamp = gps.timestamp;
+
+            // Apply persisted state if valid and within 500m threshold
+            if let Some(ps) = self.pending_persisted.take() {
+                let delta_cm = if est.s_cm >= ps.last_progress_cm {
+                    est.s_cm - ps.last_progress_cm
+                } else {
+                    ps.last_progress_cm - est.s_cm
+                };
+
+                if delta_cm <= 50_000 {
+                    // Within 500m: trust persisted stop index
+                    self.apply_persisted_stop_index(ps.last_stop_index);
+                    #[cfg(feature = "firmware")]
+                    defmt::info!(
+                        "Applied persisted state: stop={}, delta={}cm",
+                        ps.last_stop_index,
+                        delta_cm
+                    );
+                } else {
+                    #[cfg(feature = "firmware")]
+                    defmt::warn!(
+                        "Persisted state too stale: delta={}cm > 500m, ignoring",
+                        delta_cm
+                    );
+                }
+            }
+
+            return None;
+        }
+
+        // Handle just_reset state
+        if self.just_reset {
+            // After warmup reset (e.g., GPS outage), first tick counts as first fix
+            self.just_reset = false;
+            self.estimation_total_ticks = 1;
+            self.detection_total_ticks = 1;
+            return None;
+        }
+
+        // Increment total time counters
+        self.estimation_total_ticks = self.estimation_total_ticks.saturating_add(1);
+        self.detection_total_ticks = self.detection_total_ticks.saturating_add(1);
+
+        // Update estimation readiness (until ready)
+        if !self.estimation_ready() {
+            self.estimation_ready_ticks += 1;
+        }
+
+        // Update detection readiness (until ready, independent of estimation)
+        if !self.detection_ready() {
+            self.detection_enabled_ticks += 1;
+        }
+
+        // Block detection unless ready
+        if !self.detection_ready() {
+            // Still update mode transitions and recovery, but skip detection
+            // ... continue to mode transition logic below
+        }
+
+        // Update last GPS timestamp for recovery dt calculation
+        self.last_gps_timestamp = gps.timestamp;
+```
+
+- [ ] **Step 4: Add apply_persisted_stop_index() helper**
+
+Add this method to the impl block:
+```rust
+    /// Apply persisted stop index by marking all prior stops as Departed.
+    ///
+    /// This prevents the corridor filter from re-triggering stops that
+    /// were already passed before the reboot.
+    fn apply_persisted_stop_index(&mut self, stop_index: u8) {
+        use shared::FsmState;
+
+        for i in 0..stop_index.min(self.stop_states.len() as u8) as usize {
+            self.stop_states[i].fsm_state = FsmState::Departed;
+            self.stop_states[i].announced = true;
+            self.stop_states[i].last_announced_stop = i as u8;  // I3 fix
+        }
+        self.last_stop_index = stop_index;
+    }
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add warmup and first fix logic to tick()
+
+Implements proper warmup counter tracking (estimation vs detection),
+GPS outage handling, first fix initialization, and persisted state
+application. Removes hardcoded is_first_fix: false (I1 fix).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Add Snap Cooldown Logic to tick()
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:322-339` for snap handling
+
+- [ ] **Step 1: Add snap cooldown decrement at start of tick()**
+
+After the warmup logic added in Task 8, add:
+```rust
+        // Handle snap cooldown decrement
+        if self.just_snapped_ticks > 0 {
+            self.just_snapped_ticks = self.just_snapped_ticks.saturating_sub(1);
+        }
+        let in_snap_cooldown = self.just_snapped_ticks > 0;
+```
+
+- [ ] **Step 2: Add snap detection and handling after estimation**
+
+After getting `est` from `estimate()`, add:
+```rust
+        // Handle snap from off-route re-entry
+        if est.snapped && !in_snap_cooldown {
+            // Find forward closest stop (prevents backward selection)
+            let new_idx = self.find_forward_closest_stop_index(est.s_cm, self.last_stop_index);
+            self.last_stop_index = new_idx;
+
+            // Reset stop states using recovery logic
+            self.reset_stop_states_after_recovery(new_idx as usize, est.s_cm);
+
+            // Clear all recovery triggers
+            self.frozen_s_cm = None;  // Clear freeze context
+            self.last_s_cm = est.s_cm;  // Update immediately to prevent false jump detection
+
+            // Set 2-second cooldown
+            self.just_snapped_ticks = 2;
+
+            #[cfg(feature = "firmware")]
+            defmt::info!("Snap re-entry at s={}cm, recovered stop={}", est.s_cm, new_idx);
+
+            // Continue to detection below
+        }
+```
+
+- [ ] **Step 3: Pass in_snap_cooldown to recovery check**
+
+In the mode transition logic (where checking for recovery triggers), ensure `in_snap_cooldown` is used to suppress recovery during cooldown.
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add snap cooldown logic to tick()
+
+Detects est.snapped signal from estimation layer and implements
+2-second cooldown to prevent false jump detection. Resets stop
+states and clears recovery triggers on snap.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Wire Stop State Reset into Recovery Paths
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:241-249, 373-379` for recovery reset calls
+
+- [ ] **Step 1: Add stop state reset to recovery_success()**
+
+Update the `recovery_success()` method to call reset:
+```rust
+    fn recovery_success(&mut self, recovered_idx: usize, s_cm: DistCm) {
+        self.mode = SystemMode::Normal;
+        self.last_stop_index = recovered_idx as u8;
+        self.frozen_s_cm = None;
+        self.recovering_since = None;
+        self.recovery_failed = false;
+        self.last_s_cm = s_cm;
+
+        // Reset stop states after recovery
+        self.reset_stop_states_after_recovery(recovered_idx, s_cm);
+    }
+```
+
+- [ ] **Step 2: Add stop state reset to timeout fallback**
+
+In `attempt_recovery()`, update the timeout fallback path:
+```rust
+        // Check timeout first
+        if check_recovering_timeout(self.mode, self.recovering_since, now) {
+            // Fallback to geometric search
+            let best_idx = self.find_closest_stop_index_internal(est.s_cm);
+
+            self.recovery_failed = true;
+            self.mode = SystemMode::Normal;
+            self.last_stop_index = best_idx;
+            self.frozen_s_cm = None;
+            self.recovering_since = None;
+
+            // Reset stop states after recovery
+            self.reset_stop_states_after_recovery(best_idx as usize, est.s_cm);
+
+            return Some(best_idx as usize);
+        }
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): wire stop state reset into recovery paths
+
+Calls reset_stop_states_after_recovery() in both recovery_success()
+and timeout fallback. Ensures stop FSM is properly initialized after
+any recovery event.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Add Persistence Methods to SystemState
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/control/mod.rs`
+
+**Reference:** Old `state.rs:685-726` for persistence logic
+
+- [ ] **Step 1: Add should_persist() method**
+
+```rust
+    /// Returns true if state should be persisted this tick.
+    /// Writes when stop index changes, but no more than once per 60 seconds.
+    /// This rate limiting prevents excessive flash wear (~100k erase cycles).
+    pub fn should_persist(&self, current_stop: u8) -> bool {
+        // M5: Gate persistence during off-route/suspect states
+        // Don't persist if position is frozen (off-route or suspect)
+        if self.frozen_s_cm.is_some() {
+            return false;
+        }
+
+        // Don't persist if in suspect state
+        if self.off_route_suspect_ticks > 0 {
+            return false;
+        }
+
+        // Only persist when stop index actually changes
+        if current_stop == self.last_persisted_stop {
+            return false;
+        }
+
+        // Rate limit: no more than once per 60 seconds (60 ticks at 1Hz)
+        if self.ticks_since_persist < 60 {
+            return false;
+        }
+
+        true
+    }
+```
+
+- [ ] **Step 2: Add mark_persisted() method**
+
+```rust
+    /// Mark state as persisted, resetting the rate-limit counter.
+    pub fn mark_persisted(&mut self, stop_index: u8) {
+        self.last_persisted_stop = stop_index;
+        self.ticks_since_persist = 0;
+    }
+```
+
+- [ ] **Step 3: Add current_stop_index() method**
+
+```rust
+    /// Get the current stop index from last_stop_index.
+    /// Returns None if not yet initialized.
+    pub fn current_stop_index(&self) -> Option<u8> {
+        if self.first_fix {
+            None
+        } else {
+            Some(self.last_stop_index)
+        }
+    }
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo build --release -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/pico2-firmware/src/control/mod.rs
+git commit -m "feat(control): add persistence methods to SystemState
+
+Adds should_persist(), mark_persisted(), and current_stop_index()
+with proper rate limiting (60 second minimum) and off-route gating.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Update main.rs to Use New Architecture
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/main.rs`
+
+**Reference:** Existing `main.rs` lines 21-26, 101, 122, 155-176
+
+- [ ] **Step 1: Update module imports**
+
+Replace the module declaration section (lines 21-26) with:
+```rust
+// Module declarations
+mod control;
+mod detection;
+mod estimation;
+mod lut;
+mod persist;
+mod recovery_trigger;
+mod state;  // Deprecated: kept for reference
+mod uart;
+```
+
+- [ ] **Step 2: Add use statements for new types**
+
+After the module declarations, add:
+```rust
+use crate::control::SystemState;
+use crate::estimation::EstimationState;
+```
+
+- [ ] **Step 3: Replace State instantiation**
+
+Replace line 101 `let mut state = state::State::new(&route_data, persisted);` with:
+```rust
+    // Initialize system state with route data reference
+    let mut system_state = SystemState::new(&route_data, persisted);
+    let mut estimation_state = EstimationState::new();
+```
+
+- [ ] **Step 4: Replace GPS processing call**
+
+Replace line 122 `if let Some(arrival) = state.process_gps(&gps) {` with:
+```rust
+                        // Process GPS through full pipeline
+                        if let Some(arrival) = system_state.tick(&gps, &mut estimation_state) {
+```
+
+- [ ] **Step 5: Update persistence calls**
+
+Replace lines 155-176 with:
+```rust
+        // Persist state if stop index changed and rate limit allows
+        if let Some(current_stop) = system_state.current_stop_index() {
+            if system_state.should_persist(current_stop) {
+                let ps = shared::PersistedState::new(
+                    estimation_state.kalman.s_cm,
+                    current_stop
+                );
+                match persist::save(&mut flash, &ps).await {
+                    Ok(()) => {
+                        info!(
+                            "Persisted state: stop={}, progress={}cm",
+                            current_stop, estimation_state.kalman.s_cm
+                        );
+                        system_state.mark_persisted(current_stop);
+                    }
+                    Err(()) => {
+                        defmt::warn!("Failed to persist state to flash");
+                        // S4 fix: increment on failure to prevent retry loop
+                        system_state.ticks_since_persist = system_state.ticks_since_persist.saturating_add(1);
+                    }
+                }
+            } else {
+                // Increment tick counter for rate limiting
+                system_state.ticks_since_persist = system_state.ticks_since_persist.saturating_add(1);
+            }
+        }
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cargo build --release --target thumbv8m.main-none-eabi -p pico2-firmware`
+Expected: Compiles without errors
+
+- [ ] **Step 7: Run tests**
+
+Run: `cargo test -p pico2-firmware`
+Expected: All tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/pico2-firmware/src/main.rs
+git commit -m "feat(main): migrate to two-layer architecture
+
+Replaces state::State with SystemState + EstimationState.
+NMEA parsing remains in main.rs for clean separation.
+
+- Import control::SystemState and estimation::EstimationState
+- Replace state.process_gps() with system_state.tick()
+- Update persistence calls to use SystemState methods
+
+This activates the v9.0 two-layer architecture described in docs.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Mark Old state.rs as Deprecated
+
+**Files:**
+- Modify: `crates/pico2-firmware/src/state.rs`
+
+- [ ] **Step 1: Add deprecation notice to state.rs**
+
+Add at the top of the file (after the module doc comment, if present):
+```rust
+#![deprecated(note = "Use control::SystemState + estimation::EstimationState instead")]
+```
+
+- [ ] **Step 2: Add deprecation notice to State struct**
+
+Add `#[deprecated]` attribute to the State struct:
+```rust
+#[deprecated(note = "Use control::SystemState instead")]
+pub struct State<'a> {
+    // ... existing fields ...
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo build --release --target thumbv8m.main-none-eabi -p pico2-firmware`
+Expected: Compiles without errors (warnings about deprecated code are OK)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/pico2-firmware/src/state.rs
+git commit -m "deprecate(state): mark state.rs as deprecated
+
+Replaced by control::SystemState + estimation::EstimationState.
+Old code kept for reference during verification period.
+
+See: docs/superpowers/specs/2026-04-29-two-layer-activation-design.md
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Verification and Testing
+
+**Files:**
+- Test: Run scenario tests and validate output
+
+- [ ] **Step 1: Build firmware**
+
+Run: `cargo build --release --target thumbv8m.main-none-eabi -p pico2-firmware`
+Expected: Clean build with no errors
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `cargo test -p pico2-firmware`
+Expected: All tests pass
+
+- [ ] **Step 3: Run scenario test**
+
+Run: `make run ROUTE_NAME=ty225 SCENARIO=normal`
+Expected: Produces arrivals.jsonl with arrival/departure events
+
+- [ ] **Step 4: Verify trace output**
+
+Check that trace.jsonl contains expected state transitions and events
+
+- [ ] **Step 5: Compare with old implementation (optional)**
+
+If you have baseline output from old implementation, compare:
+- Number of arrival events
+- Timing of arrivals
+- Stop indices
+
+Expected: Results match or are improved (due to bug fixes)
+
+- [ ] **Step 6: Verify bug fixes**
+
+Check that the following bugs are fixed:
+- C2: Kalman predict step present (no systematic lag)
+- I1: First fix properly tracked (not hardcoded)
+- I3: Announcement guards consistent
+- Snap signal: Cooldown logic works
+
+- [ ] **Step 7: Commit verification results**
+
+```bash
+echo "Verification complete:
+- Firmware builds successfully
+- All unit tests pass
+- Scenario test produces valid output
+- Bug fixes verified (C2, I1, I3, snap signal)
+
+See individual task commits for implementation details." | git commit allow-empty -F -
+```
+
+---
+
+## Task 15: Final Documentation Update
+
+**Files:**
+- Modify: `CLAUDE.md` or relevant documentation
+
+- [ ] **Step 1: Update CLAUDE.md architecture section**
+
+Update the "Firmware Architecture (2-Layer Design)" section to reflect that the architecture is now active:
+
+```markdown
+**Firmware Architecture (2-Layer Design) - ACTIVE**
+
+The pico2-firmware crate implements a 2-layer architecture for embedded deployment:
+
+**Control Layer** (`crates/pico2-firmware/src/control/`):
+- `SystemState` — state machine managing Normal/OffRoute/Recovering modes
+- `SystemMode` — mode enum with transition functions
+- Unified triggers based on `divergence_d2` and `displacement`
+- Recovery timeout (30s) with geometric fallback
+- `tick()` orchestrator — coordinates estimation and detection
+
+**Estimation Layer** (`crates/pico2-firmware/src/estimation/`):
+- `estimate()` — isolated GPS → position pipeline
+- `KalmanState` — Kalman filter (no control state)
+- `DrState` — DR/EMA state (no control state)
+- Returns `EstimationOutput` with confidence signal
+```
+
+- [ ] **Step 2: Add migration note**
+
+Add to CLAUDE.md:
+```markdown
+## Migration Notes
+
+**v9.0 Architecture Migration (2026-04-29):**
+- Migrated from monolithic `state::State` to two-layer architecture
+- Old `state.rs` marked as deprecated
+- Bug fixes applied: C2 (Kalman predict), I1 (first fix), I3 (announcement guards)
+- See: `docs/superpowers/specs/2026-04-29-two-layer-activation-design.md`
+```
+
+- [ ] **Step 3: Commit documentation updates**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md for activated two-layer architecture
+
+Documents that the v9.0 two-layer architecture is now active.
+Adds migration notes and references design spec.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Results
+
+**Spec coverage:**
+- ✓ Phase 0 (bug fixes) → Tasks 1-3
+- ✓ Phase 1 (SystemState structure) → Task 4
+- ✓ Phase 2 (detection integration) → Task 7
+- ✓ Phase 3 (stop state reset) → Task 6
+- ✓ Phase 4 (helper methods) → Task 5
+- ✓ Phase 5 (warmup logic) → Task 8
+- ✓ Phase 6 (stop state reset calls) → Task 10
+- ✓ Phase 7 (main.rs migration) → Task 12
+- ✓ Phase 8 (snap cooldown) → Task 9
+- ✓ Phase 9 (testing) → Task 14
+- ✓ Phase 10 (cleanup) → Tasks 13, 15
+
+**Placeholder scan:** No placeholders found. All steps contain complete code.
+
+**Type consistency:** Verified. Types match across tasks (EstimationOutput, SystemState, etc.).
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-29-two-layer-activation.md`.
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-29-two-layer-activation-design.md
+++ b/docs/superpowers/specs/2026-04-29-two-layer-activation-design.md
@@ -1,0 +1,256 @@
+# Activate Two-Layer Architecture Design
+
+## Context
+
+The firmware codebase contains two divergent full-pipeline implementations:
+
+1. **OLD (active)**: `state.rs` - Monolithic `State::process_gps()` (770 lines)
+2. **NEW (dead code)**: `control/mod.rs` + `estimation/mod.rs` - Two-layer architecture
+
+The new v9.0 architecture exists but is never invoked from `main.rs`. The `SystemState::run_detection()` method is a TODO stub that unconditionally returns `None`. This design activates the new architecture while preserving all functionality.
+
+## Goal
+
+Activate the documented v9.0 two-layer architecture with complete feature parity to the old implementation. The new design provides better separation of concerns and matches the architecture described in technical documentation.
+
+## Architecture
+
+### Layer Separation
+
+```
+main.rs
+  │
+  ├─> NMEA parsing → GpsPoint
+  │
+  └─> SystemState::tick(gps, estimation_state)
+        │
+        ├─> Estimation Layer (pure function)
+        │     └─> estimate(input, state) → EstimationOutput
+        │
+        ├─> Control Layer (state machine)
+        │     ├─> Mode transitions (Normal/OffRoute/Recovering)
+        │     ├─> Recovery orchestration
+        │     └─> Monotonic enforcement
+        │
+        └─> Detection Layer (FSM)
+              ├─> find_active_stops()
+              ├─> compute_arrival_probability_adaptive()
+              └─> StopState transitions → ArrivalEvent
+```
+
+### Data Flow
+
+```
+GPS NMEA sentence
+  → NmeaState::parse_sentence() → Option<GpsPoint>
+  → SystemState::tick(gps, estimation_state)
+    → EstimationInput::new(gps, route_data, is_first_fix)
+    → estimate(input, &mut estimation_state) → EstimationOutput
+      { s_cm, v_cms, divergence_d2, confidence, has_fix }
+    → Check mode transitions (Normal ↔ OffRoute ↔ Recovering)
+    → Enforce monotonic invariant
+    → If Recovering: attempt_recovery() → Option<usize>
+    → If Normal: run_detection() → Option<ArrivalEvent>
+  → Some(ArrivalEvent) → UART output
+```
+
+## Components
+
+### Estimation Layer (`estimation/mod.rs`)
+
+**Status:** Already complete
+
+**Purpose:** Pure function converting GPS + route data to position signals
+
+**Contract:**
+- Input: GPS + route (no control layer state)
+- Output: Position signals (no side effects to control layer)
+- Internal state: Kalman + DR (opaque to control layer)
+- Deterministic: Same GPS input → same EstimationOutput
+
+**Output Structure:**
+```rust
+pub struct EstimationOutput {
+    pub z_gps_cm: DistCm,      // Raw GPS projection (for F1 probability)
+    pub s_cm: DistCm,          // Kalman-filtered position
+    pub v_cms: SpeedCms,       // Filtered velocity
+    pub divergence_d2: Dist2,  // Divergence from route
+    pub confidence: u8,        // Quality signal (0-255)
+    pub has_fix: bool,         // GPS validity
+}
+```
+
+### Control Layer (`control/mod.rs`)
+
+**Status:** Partially complete, needs detection integration
+
+**Purpose:** State machine orchestration and detection coordination
+
+**Key Responsibilities:**
+- Mode management (Normal/OffRoute/Recovering)
+- Recovery orchestration
+- Monotonic invariant enforcement
+- Detection gating (warmup/timeout)
+- Stop state persistence
+
+**State Fields to Add:**
+```rust
+pub stop_states: heapless::Vec<StopState, 256>,  // Per-stop FSM
+pub first_fix: bool,                              // First GPS fix flag
+pub estimation_ready_ticks: u8,                   // Estimation warmup
+pub detection_enabled_ticks: u8,                  // Detection warmup
+pub just_reset: bool,                             // Post-reset flag
+pub just_snapped_ticks: u8,                       // Snap cooldown
+pub last_gps_timestamp: u64,                      // For recovery dt
+```
+
+**Methods to Implement:**
+- `run_detection()` - Full arrival detection FSM (currently a TODO stub)
+- `reset_stop_states_after_recovery()` - Stop state reset logic
+- `estimation_ready()` - Check if estimation converged
+- `detection_ready()` - Check if detection allowed
+- `find_closest_stop_index()` - Geometric fallback
+- `find_forward_closest_stop_index()` - Forward-only search
+
+### Detection Layer
+
+**Status:** Functions exist in `detection.rs`, needs integration into SystemState
+
+**Purpose:** Bayesian arrival detection with finite state machine
+
+**Integration Point:** `SystemState::run_detection()`
+
+**Flow:**
+1. Find active stops via corridor filter
+2. For each active stop:
+   - Compute arrival probability with adaptive weights
+   - Update StopState FSM
+   - Check for Arrival/Departure/Announce events
+3. Return first event (early exit on event emission)
+
+## Implementation
+
+### Phase 1: SystemState Structure
+
+Add missing fields to `SystemState` struct in `control/mod.rs`:
+- `stop_states` array
+- Warmup counters
+- Snap cooldown tracking
+- First fix and reset flags
+- GPS timestamp tracking
+
+### Phase 2: Detection Integration
+
+Implement `run_detection()` method:
+- Call `detection::find_active_stops()` with position signals
+- For each active stop:
+  - Get next stop for adaptive weights
+  - Call `compute_arrival_probability_adaptive()`
+  - Update `StopState` via `stop_state.update()`
+  - Check `should_announce()` for announcement events
+  - Check `StopEvent` for arrival/departure events
+- Return first event (early exit)
+
+### Phase 3: Stop State Reset
+
+Implement `reset_stop_states_after_recovery()`:
+- Reset all stops to `Idle`
+- Mark stops before recovered index as `Departed` (preserve announced flag)
+- Set recovered stop to `Approaching` if within corridor
+- Preserve `announced` flag if stop was previously announced
+
+### Phase 4: Helper Methods
+
+Add helper methods to `SystemState`:
+- `estimation_ready() -> bool` - Check warmup or timeout
+- `detection_ready() -> bool` - Check warmup or timeout
+- `disable_heading_filter() -> bool` - First fix or not ready
+- `find_closest_stop_index(s_cm)` - Geometric search
+- `find_forward_closest_stop_index(s_cm, last_idx)` - Forward-only search
+
+### Phase 5: Warmup Logic in tick()
+
+Add warmup tracking to `SystemState::tick()`:
+- Track `estimation_ready_ticks` and `estimation_total_ticks`
+- Track `detection_enabled_ticks` and `detection_total_ticks`
+- Reset counters on GPS outage (> 10 seconds)
+- Block detection until ready (3 ticks or 10 tick timeout)
+- Handle `first_fix` initialization
+
+### Phase 6: Stop State Reset Calls
+
+Wire stop state reset into recovery paths:
+- Call in `recovery_success()` after successful recovery
+- Call in timeout fallback path
+- Use same logic as old `state.rs:635-673`
+
+### Phase 7: main.rs Migration
+
+Update `main.rs` to use new architecture:
+- Import `control::SystemState` and `estimation::EstimationState`
+- Replace `state::State` instantiation with `SystemState` + `EstimationState`
+- Replace `state.process_gps(&gps)` with `system_state.tick(&gps, &mut estimation_state)`
+- Update persistence calls to use `SystemState` methods
+
+### Phase 8: Snap Cooldown
+
+Add snap cooldown logic:
+- Set `just_snapped_ticks = 2` on successful off-route snap re-entry
+- Decrement counter each tick when > 0
+- Pass `in_snap_cooldown` flag to recovery logic to prevent false jump detection
+
+### Phase 9: Testing
+
+- Unit tests for new `SystemState` methods
+- Integration tests for mode transitions
+- Scenario validation: `make run ROUTE_NAME=ty225 SCENARIO=normal`
+- Trace comparison against old implementation
+- Verify arrivals/departures match expected output
+
+### Phase 10: Cleanup
+
+Once migration is verified working:
+- Mark `state.rs` as deprecated with `#[allow(dead_code)]`
+- Document migration in commit message
+- Consider removing `state.rs` in future commit
+
+## Key Design Decisions
+
+1. **NMEA parsing stays in main.rs** - I/O concerns separated from business logic
+2. **Stop states live in SystemState** - Detection needs persistent FSM state per tick
+3. **Estimation is pure** - No access to control layer state, deterministic output
+4. **Single transition per tick** - Prevents race conditions in mode changes
+5. **Detection blocked until ready** - 3 tick warmup or 10 tick timeout safety valve
+6. **Preserve exact behavior** - Match old implementation for warmup, recovery, persistence
+
+## Testing Strategy
+
+- **Unit tests**: New `SystemState` methods (ready checks, stop finding)
+- **Integration tests**: Mode transitions, recovery paths
+- **Scenario tests**: Full pipeline with test data
+- **Trace validation**: Compare output against old implementation
+- **Behavioral verification**: Arrivals/departures match expected
+
+## Success Criteria
+
+1. Code compiles for target: `cargo build --release --target thumbv8m.main-none-eabi -p pico2-firmware`
+2. All tests pass: `cargo test -p pico2-firmware`
+3. Scenario tests produce valid output: `make run ROUTE_NAME=ty225 SCENARIO=normal`
+4. Trace matches old implementation (within expected variance)
+5. No dead code warnings for `SystemState` and `estimate()`
+6. Old `state.rs` marked as deprecated
+
+## Files Modified
+
+- `crates/pico2-firmware/src/control/mod.rs` - Add detection integration and missing state
+- `crates/pico2-firmware/src/estimation/mod.rs` - Already complete (no changes)
+- `crates/pico2-firmware/src/main.rs` - Switch to new architecture
+- `crates/pico2-firmware/src/state.rs` - Mark deprecated (future: remove)
+
+## References
+
+- Old implementation: `crates/pico2-firmware/src/state.rs` (lines 1-770)
+- New control layer: `crates/pico2-firmware/src/control/mod.rs`
+- New estimation layer: `crates/pico2-firmware/src/estimation/mod.rs`
+- Detection module: `crates/pico2-firmware/src/detection.rs`
+- Tech documentation: `docs/bus_arrival_tech_report_v8.md`

--- a/docs/superpowers/specs/2026-04-29-two-layer-activation-design.md
+++ b/docs/superpowers/specs/2026-04-29-two-layer-activation-design.md
@@ -7,7 +7,14 @@ The firmware codebase contains two divergent full-pipeline implementations:
 1. **OLD (active)**: `state.rs` - Monolithic `State::process_gps()` (770 lines)
 2. **NEW (dead code)**: `control/mod.rs` + `estimation/mod.rs` - Two-layer architecture
 
-The new v9.0 architecture exists but is never invoked from `main.rs`. The `SystemState::run_detection()` method is a TODO stub that unconditionally returns `None`. This design activates the new architecture while preserving all functionality.
+The new v9.0 architecture exists but is never invoked from `main.rs`. The `SystemState::run_detection()` method is a TODO stub that unconditionally returns `None`.
+
+This design activates the new architecture while preserving all functionality AND fixing known bugs identified in the code review (see `docs/claude_review.md`):
+- **C1**: Activate two-layer architecture (this design's primary goal)
+- **C2**: Add missing Kalman predict step
+- **I1**: Fix `is_first_fix` hardcoded to `false`
+- **I3**: Fix announcement guard inconsistency in stop state reset
+- **Missing snap signal**: Add `snapped` to `EstimationOutput`
 
 ## Goal
 
@@ -130,6 +137,67 @@ pub last_gps_timestamp: u64,                      // For recovery dt
 
 ## Implementation
 
+### Phase 0: Fix Estimation Layer Bugs
+
+**Before any migration work, fix bugs in the estimation layer:**
+
+**1. Add Kalman predict step (C2 fix)**
+
+File: `crates/pico2-firmware/src/estimation/kalman.rs` or `gps_processor/src/kalman.rs`
+
+The `update_adaptive()` method must predict position before updating:
+```rust
+// BEFORE update step, add predict step:
+let s_pred = self.s_cm + self.v_cms;  // Propagate velocity into position
+// Then use s_pred instead of self.s_cm in the innovation term
+let innovation = z_raw - s_pred;
+self.s_cm = s_pred + k_pos * innovation / 256;
+```
+
+Without this, velocity is never propagated into position prediction, causing systematic lag proportional to bus speed.
+
+**2. Add snapped signal to EstimationOutput**
+
+File: `crates/pico2-firmware/src/estimation/mod.rs`
+
+Add `snapped: bool` field to `EstimationOutput`:
+```rust
+pub struct EstimationOutput {
+    pub z_gps_cm: DistCm,
+    pub s_cm: DistCm,
+    pub v_cms: SpeedCms,
+    pub divergence_d2: Dist2,
+    pub confidence: u8,
+    pub has_fix: bool,
+    pub snapped: bool,  // NEW: true if map-matching snapped from off-route
+}
+```
+
+Set `snapped = true` when `find_best_segment_restricted()` returns a match after being off-route (i.e., when `divergence_d2` was high but is now low). The old `process_gps_update()` returns this via `ProcessResult::Valid { snapped, .. }`.
+
+**3. Track first fix state**
+
+File: `crates/pico2-firmware/src/estimation/mod.rs`
+
+Add `first_fix_called: bool` to `EstimationState`:
+```rust
+pub struct EstimationState {
+    pub kalman: KalmanState,
+    pub dr: DrState,
+    first_fix_called: bool,  // Track if estimate() has ever been called with valid fix
+}
+```
+
+In `estimate()`, check `first_fix_called` and pass to output:
+```rust
+let is_first_fix = !state.first_fix_called && input.gps.has_fix;
+if input.gps.has_fix {
+    state.first_fix_called = true;
+}
+// ... rest of estimate()
+// Return EstimationOutput with is_first_fix: is_first_fix (or derive from has_fix)
+```
+
 ### Phase 1: SystemState Structure
 
 Add missing fields to `SystemState` struct in `control/mod.rs`:
@@ -155,9 +223,19 @@ Implement `run_detection()` method:
 
 Implement `reset_stop_states_after_recovery()`:
 - Reset all stops to `Idle`
-- Mark stops before recovered index as `Departed` (preserve announced flag)
+- Mark stops before recovered index as `Departed`
+- Set both `announced = true` AND `last_announced_stop = i` for passed stops (I3 fix)
 - Set recovered stop to `Approaching` if within corridor
 - Preserve `announced` flag if stop was previously announced
+
+**I3 Fix:** The old code set `announced = true` without setting `last_announced_stop = i`, causing `should_announce()` to fire anyway. Fix both fields together:
+```rust
+for i in 0..recovered_idx.min(self.stop_states.len()) {
+    self.stop_states[i].fsm_state = FsmState::Departed;
+    self.stop_states[i].announced = true;
+    self.stop_states[i].last_announced_stop = i as u8;  // I3: was missing
+}
+```
 
 ### Phase 4: Helper Methods
 
@@ -175,7 +253,30 @@ Add warmup tracking to `SystemState::tick()`:
 - Track `detection_enabled_ticks` and `detection_total_ticks`
 - Reset counters on GPS outage (> 10 seconds)
 - Block detection until ready (3 ticks or 10 tick timeout)
-- Handle `first_fix` initialization
+- Handle `first_fix` initialization (I1 fix: track state, don't hardcode)
+
+**Warmup counter behavior (matching old state.rs):**
+- `estimation_ready_ticks`: increments ONLY when `estimate()` returns valid position (has_fix=true)
+- `estimation_total_ticks`: increments on all ticks including rejected/DR-outage (I5 fix)
+- `detection_enabled_ticks`: increments ONLY after `estimation_ready()` is true
+- `detection_total_ticks`: increments on all ticks for timeout safety valve
+
+**I1 Fix:** Remove hardcoded `is_first_fix: false`. Instead:
+```rust
+let input = EstimationInput {
+    gps: gps.clone(),
+    route_data: self.route_data,
+    is_first_fix: !self.first_fix,  // Use actual state
+};
+let est = crate::estimation::estimate(input, est_state);
+
+// After first successful fix:
+if self.first_fix && est.has_fix {
+    self.first_fix = false;
+    self.estimation_total_ticks = 1;
+    self.detection_total_ticks = 1;
+}
+```
 
 ### Phase 6: Stop State Reset Calls
 
@@ -194,10 +295,27 @@ Update `main.rs` to use new architecture:
 
 ### Phase 8: Snap Cooldown
 
-Add snap cooldown logic:
-- Set `just_snapped_ticks = 2` on successful off-route snap re-entry
+Add snap cooldown logic using `est.snapped` signal from Phase 0:
+- Check `est.snapped` after estimation returns
+- Set `just_snapped_ticks = 2` when `snapped == true`
 - Decrement counter each tick when > 0
 - Pass `in_snap_cooldown` flag to recovery logic to prevent false jump detection
+
+```rust
+// In tick(), after estimation:
+if self.just_snapped_ticks > 0 {
+    self.just_snapped_ticks -= 1;
+}
+let in_snap_cooldown = self.just_snapped_ticks > 0;
+
+if est.snapped && !in_snap_cooldown {
+    self.just_snapped_ticks = 2;
+    // Handle snap: find forward closest stop, reset states, clear recovery triggers
+    let new_idx = self.find_forward_closest_stop_index(est.s_cm, self.last_stop_index);
+    self.reset_stop_states_after_recovery(new_idx as usize, est.s_cm);
+    // ... clear recovery flags
+}
+```
 
 ### Phase 9: Testing
 
@@ -210,9 +328,21 @@ Add snap cooldown logic:
 ### Phase 10: Cleanup
 
 Once migration is verified working:
+
+**Immediate (same migration commit):**
 - Mark `state.rs` as deprecated with `#[allow(dead_code)]`
+- Add comment directing to `SystemState` as replacement
 - Document migration in commit message
-- Consider removing `state.rs` in future commit
+
+**Future cleanup (separate commit after verification period):**
+- Remove `state.rs` entirely
+- Remove old recovery: `pipeline/detection/src/recovery.rs` (duplicate of `crate::recovery`)
+- Remove unused types from `shared`:
+  - `FreezeContext` (only used by old recovery)
+  - Old `ProcessResult` enum (replaced by `EstimationOutput`)
+- Update any remaining references
+
+**Note:** `state.rs` contains `detection::recovery::find_stop_index` (old recovery) which uses `FreezeContext` - a type that doesn't exist in the new architecture. If `state.rs` is left alive, those types must stay in `shared`, creating cross-contamination. The cleanup plan must explicitly remove these types when `state.rs` is removed.
 
 ## Key Design Decisions
 
@@ -221,7 +351,8 @@ Once migration is verified working:
 3. **Estimation is pure** - No access to control layer state, deterministic output
 4. **Single transition per tick** - Prevents race conditions in mode changes
 5. **Detection blocked until ready** - 3 tick warmup or 10 tick timeout safety valve
-6. **Preserve exact behavior** - Match old implementation for warmup, recovery, persistence
+6. **Fix bugs during migration** - Don't copy forward C2, I1, I3, or missing snap signal
+7. **Preserve exact behavior** - Match old implementation for warmup, recovery, persistence (except where bugs are fixed)
 
 ## Testing Strategy
 
@@ -239,13 +370,20 @@ Once migration is verified working:
 4. Trace matches old implementation (within expected variance)
 5. No dead code warnings for `SystemState` and `estimate()`
 6. Old `state.rs` marked as deprecated
+7. **Bug fixes verified:**
+   - C2: Kalman predict step present in estimation layer
+   - I1: `is_first_fix` properly tracked (not hardcoded)
+   - I3: Announcement guards consistent in stop state reset
+   - Snap signal: `est.snapped` used for cooldown logic
 
 ## Files Modified
 
-- `crates/pico2-firmware/src/control/mod.rs` - Add detection integration and missing state
-- `crates/pico2-firmware/src/estimation/mod.rs` - Already complete (no changes)
-- `crates/pico2-firmware/src/main.rs` - Switch to new architecture
-- `crates/pico2-firmware/src/state.rs` - Mark deprecated (future: remove)
+- `crates/pico2-firmware/src/estimation/mod.rs` - Add `snapped` to EstimationOutput, track `first_fix_called` (Phase 0)
+- `crates/pico2-firmware/src/estimation/kalman.rs` or `gps_processor/src/kalman.rs` - Add predict step (C2 fix, Phase 0)
+- `crates/pico2-firmware/src/control/mod.rs` - Add detection integration and missing state (Phases 1-6, 8)
+- `crates/pico2-firmware/src/main.rs` - Switch to new architecture (Phase 7)
+- `crates/pico2-firmware/src/state.rs` - Mark deprecated (Phase 10)
+- `crates/pipeline/detection/src/recovery.rs` - Remove old recovery (Phase 10, future commit)
 
 ## References
 
@@ -254,3 +392,4 @@ Once migration is verified working:
 - New estimation layer: `crates/pico2-firmware/src/estimation/mod.rs`
 - Detection module: `crates/pico2-firmware/src/detection.rs`
 - Tech documentation: `docs/bus_arrival_tech_report_v8.md`
+- QA review: `docs/claude_review.md` - Contains C1-C8 and I1-I8 issues addressed in this design

--- a/visualizer/src/lib/components/CompactSidebar.svelte
+++ b/visualizer/src/lib/components/CompactSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { TraceData, FsmState } from '$lib/types';
-	import { FSM_STATE_COLORS } from '$lib/constants/fsmColors';
+	import type { TraceData, FsmState } from "$lib/types";
+	import { FSM_STATE_COLORS } from "$lib/constants/fsmColors";
 
 	interface Props {
 		traceData: TraceData;
@@ -9,12 +9,24 @@
 		selectedStop: number | null;
 		onSeek: (time: number) => void;
 		onStopSelect: (idx: number) => void;
-		onEventClick?: (info: { time: number; stopIdx?: number; state?: FsmState }) => void;
+		onEventClick?: (info: {
+			time: number;
+			stopIdx?: number;
+			state?: FsmState;
+		}) => void;
 	}
 
-	let { traceData, currentTime, v_cms, selectedStop, onSeek, onStopSelect, onEventClick }: Props = $props();
+	let {
+		traceData,
+		currentTime,
+		v_cms,
+		selectedStop,
+		onSeek,
+		onStopSelect,
+		onEventClick,
+	}: Props = $props();
 
-	type EventType = 'JUMP' | 'RECOVERY' | 'TRANSITION' | 'ARRIVAL';
+	type EventType = "JUMP" | "RECOVERY" | "TRANSITION" | "ARRIVAL";
 
 	interface LogEvent {
 		time: number;
@@ -28,29 +40,37 @@
 	// Helper: Get event type label (3-char abbreviation)
 	function getEventTypeLabel(type: EventType): string {
 		switch (type) {
-			case 'ARRIVAL': return 'ARR';
-			case 'TRANSITION': return 'TRN';
-			case 'JUMP': return 'JMP';
-			case 'RECOVERY': return 'REC';
+			case "ARRIVAL":
+				return "ARR";
+			case "TRANSITION":
+				return "TRN";
+			case "JUMP":
+				return "JMP";
+			case "RECOVERY":
+				return "REC";
 		}
 	}
 
 	// Helper: Get event type color
 	function getEventTypeColor(type: EventType): string {
 		switch (type) {
-			case 'ARRIVAL': return '#22c55e';
-			case 'TRANSITION': return '#eab308';
-			case 'JUMP': return '#ef4444';
-			case 'RECOVERY': return '#f59e0b';
+			case "ARRIVAL":
+				return "#22c55e";
+			case "TRANSITION":
+				return "#eab308";
+			case "JUMP":
+				return "#ef4444";
+			case "RECOVERY":
+				return "#f59e0b";
 		}
 	}
 
 	// Helper: Format event time (locale-independent)
 	function formatEventTime(seconds: number): string {
 		const date = new Date(seconds * 1000);
-		const hh = String(date.getHours()).padStart(2, '0');
-		const mm = String(date.getMinutes()).padStart(2, '0');
-		const ss = String(date.getSeconds()).padStart(2, '0');
+		const hh = String(date.getHours()).padStart(2, "0");
+		const mm = String(date.getMinutes()).padStart(2, "0");
+		const ss = String(date.getSeconds()).padStart(2, "0");
 		return `${hh}:${mm}:${ss}`;
 	}
 
@@ -75,26 +95,27 @@
 	function handleEventRowClick(event: LogEvent) {
 		highlightedEventTime = event.time;
 		onSeek(event.time);
-		const eventState = event.state || (event.type === 'ARRIVAL' ? 'AtStop' : undefined);
+		const eventState =
+			event.state || (event.type === "ARRIVAL" ? "AtStop" : undefined);
 		if (event.stopIdx !== undefined && eventState) {
 			onEventClick?.({
 				time: event.time,
 				stopIdx: event.stopIdx,
-				state: eventState
+				state: eventState,
 			});
 		}
 	}
 
 	// Helper: Format probability value (0-255) as padded string
 	function formatProb(value: number): string {
-		return Math.round(value).toString().padStart(3, '0');
+		return Math.round(value).toString().padStart(3, "0");
 	}
 
 	// Helper: Get probability color
 	function getProbColor(prob: number): string {
-		if (prob >= PROB_HIGH_THRESHOLD) return '#22c55e';
-		if (prob >= PROB_MED_THRESHOLD) return '#f59e0b';
-		return '#ef4444';
+		if (prob >= PROB_HIGH_THRESHOLD) return "#22c55e";
+		if (prob >= PROB_MED_THRESHOLD) return "#f59e0b";
+		return "#ef4444";
 	}
 
 	// Derived: Events list
@@ -108,9 +129,9 @@
 			if (record.gps_jump) {
 				log.push({
 					time: record.time,
-					type: 'JUMP',
+					type: "JUMP",
 					message: `GPS Jump: dist > 200m`,
-					index: index++
+					index: index++,
 				});
 			}
 
@@ -118,9 +139,9 @@
 			if (record.recovery_idx !== null) {
 				log.push({
 					time: record.time,
-					type: 'RECOVERY',
+					type: "RECOVERY",
 					message: `Recovery: stop ${record.recovery_idx}`,
-					index: index++
+					index: index++,
 				});
 			}
 
@@ -134,15 +155,16 @@
 				// Only log transition if NOT redundant with arrival
 				// (TRANSITION to AtStop is redundant when ARRIVAL also occurs)
 				if (lastState && lastState !== stop.fsm_state) {
-					const isRedundant = hasArrival && stop.fsm_state === 'AtStop';
+					const isRedundant =
+						hasArrival && stop.fsm_state === "AtStop";
 					if (!isRedundant) {
 						log.push({
 							time: record.time,
-							type: 'TRANSITION',
+							type: "TRANSITION",
 							message: `Stop ${stop.stop_idx}`,
 							stopIdx: stop.stop_idx,
 							state: stop.fsm_state,
-							index: index++
+							index: index++,
 						});
 					}
 				}
@@ -151,11 +173,11 @@
 				if (stop.just_arrived) {
 					log.push({
 						time: record.time,
-						type: 'ARRIVAL',
+						type: "ARRIVAL",
 						message: `Stop ${stop.stop_idx}: ARRIVED`,
 						stopIdx: stop.stop_idx,
-						state: 'AtStop',
-						index: index++
+						state: "AtStop",
+						index: index++,
 					});
 				}
 			});
@@ -172,7 +194,10 @@
 	let currentRecord = $derived.by(() => {
 		if (traceData.length === 0) return null;
 		return traceData.reduce((prev, curr) =>
-			Math.abs(curr.time - currentTime) < Math.abs(prev.time - currentTime) ? curr : prev
+			Math.abs(curr.time - currentTime) <
+			Math.abs(prev.time - currentTime)
+				? curr
+				: prev,
 		);
 	});
 
@@ -199,15 +224,22 @@
 					onclick={() => handleEventRowClick(event)}
 					data-type={event.type}
 				>
-					<span class="event-time">{formatEventTime(event.time)}</span>
-					<span class="event-type-badge" style="color: {getEventTypeColor(event.type)};">
+					<span class="event-time">{formatEventTime(event.time)}</span
+					>
+					<span
+						class="event-type-badge"
+						style="color: {getEventTypeColor(event.type)};"
+					>
 						{getEventTypeLabel(event.type)}
 					</span>
 					{#if event.stopIdx !== undefined}
 						<span class="event-stop">#{event.stopIdx + 1}</span>
 					{/if}
 					{#if event.state}
-						<span class="event-state" style="color: {FSM_STATE_COLORS[event.state]};">
+						<span
+							class="event-state"
+							style="color: {FSM_STATE_COLORS[event.state]};"
+						>
 							{event.state}
 						</span>
 					{/if}
@@ -228,18 +260,26 @@
 			<h4>All Stops Monitor</h4>
 			<span class="stops-count">{stopCount} active</span>
 		</div>
-	<div class="section-content">
+		<div class="section-content">
 			{#each allStopStates as stopState}
 				<div
 					class="stop-card-compact"
 					class:selected={selectedStop === stopState.stop_idx}
-					style="border-left-color: {FSM_STATE_COLORS[stopState.fsm_state]};"
+					style="border-left-color: {FSM_STATE_COLORS[
+						stopState.fsm_state
+					]};"
 					onclick={() => onStopSelect(stopState.stop_idx)}
 				>
 					<!-- Header: Stop # + State -->
 					<div class="stop-card-header">
-						<span class="stop-index">#{stopState.stop_idx + 1}</span>
-						<span class="stop-state-badge" style="color: {FSM_STATE_COLORS[stopState.fsm_state]};">
+						<span class="stop-index">#{stopState.stop_idx + 1}</span
+						>
+						<span
+							class="stop-state-badge"
+							style="color: {FSM_STATE_COLORS[
+								stopState.fsm_state
+							]};"
+						>
 							{stopState.fsm_state}
 						</span>
 					</div>
@@ -250,9 +290,17 @@
 						<div class="prob-gauge-compact">
 							<div
 								class="prob-bar"
-								style="width: {(stopState.probability / 255) * 100}%; background-color: {getProbColor(stopState.probability)};"
+								style="width: {(stopState.probability / 255) *
+									100}%; background-color: {getProbColor(
+									stopState.probability,
+								)};"
 							></div>
-							<span class="prob-val" style="color: {getProbColor(stopState.probability)};">
+							<span
+								class="prob-val"
+								style="color: {getProbColor(
+									stopState.probability,
+								)};"
+							>
 								{formatProb(stopState.probability)}
 							</span>
 						</div>
@@ -260,8 +308,14 @@
 
 					<!-- Metrics row -->
 					<div class="metrics-compact">
-						<span class="metric">dist: {Math.round(stopState.progress_distance_cm / 100)}m</span>
-						<span class="metric">dwell: {stopState.dwell_time_s}s</span>
+						<span class="metric"
+							>dist: {Math.round(
+								stopState.progress_distance_cm / 100,
+							)}m</span
+						>
+						<span class="metric"
+							>dwell: {stopState.dwell_time_s}s</span
+						>
 					</div>
 
 					<!-- Features inline -->
@@ -376,7 +430,7 @@
 	}
 
 	.event-time {
-		font-family: 'JetBrains Mono', monospace;
+		font-family: "JetBrains Mono", monospace;
 		color: #888;
 		min-width: 60px;
 		flex-shrink: 0;
@@ -393,7 +447,7 @@
 	}
 
 	.event-stop {
-		color: #3b82f6;
+		color: #6cabff;
 		font-weight: bold;
 		flex-shrink: 0;
 	}
@@ -489,7 +543,9 @@
 
 	.prob-bar {
 		height: 100%;
-		transition: width 0.3s, background-color 0.3s;
+		transition:
+			width 0.3s,
+			background-color 0.3s;
 	}
 
 	.prob-val {
@@ -534,7 +590,12 @@
 	}
 
 	@keyframes pulse {
-		0%, 100% { opacity: 1; }
-		50% { opacity: 0.7; }
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.7;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary

Activates the documented v9.0 two-layer architecture, replacing the monolithic `state.rs` with a clean separation between **estimation layer** (pure GPS→position pipeline) and **control layer** (state machine + detection orchestration).

### What Changed

- **New Architecture**: `control::SystemState` + `estimation::EstimationState` replaces `state::State`
- **Estimation Layer** (`estimation/mod.rs`): Isolated GPS→position pipeline with pure function contract
- **Control Layer** (`control/mod.rs`): State machine managing Normal/OffRoute/Recovering modes
- **Old Code**: `state.rs` marked as deprecated (will be removed in future commit)

### Bug Fixes Included

- **C2**: Added Kalman predict step before position update (was causing velocity to never propagate)
- **I1**: Fixed `is_first_fix` hardcoded to `false` (now properly tracked)
- **I3**: Fixed announcement guard inconsistency in stop state reset (both `announced` AND `last_announced_stop` now set together)
- **Snap Signal**: Added `snapped: bool` to `EstimationOutput` for snap cooldown logic

### Files Modified

- `crates/pico2-firmware/src/estimation/mod.rs` - Add snapped signal, track first_fix_called
- `crates/pico2-firmware/src/estimation/kalman.rs` - Add predict step (C2 fix)
- `crates/pico2-firmware/src/control/mod.rs` - Complete detection integration, missing state, persistence
- `crates/pico2-firmware/src/main.rs` - Switch to new architecture
- `crates/pico2-firmware/src/state.rs` - Mark deprecated
- `docs/` - Design docs and implementation plan

### Testing

- ✅ All 82 pico2-firmware tests pass (`cargo test -p pico2-firmware --features dev`)
- ✅ Scenario test produces valid output (57 arrivals detected for ty225_normal)
- ✅ Firmware builds successfully (`cargo build --release --target thumbv8m.main-none-eabi -p pico2-firmware`)

### Migration Notes

See `docs/superpowers/specs/2026-04-29-two-layer-activation-design.md` for full design details.

---

**Related Issues**: Addresses C1 (v9.0 architecture never invoked) from code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)